### PR TITLE
docs: add CI, SonarCloud, Codecov, and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # status-please
 
+[![CI](https://github.com/pleaseai/status-please/actions/workflows/ci.yml/badge.svg)](https://github.com/pleaseai/status-please/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_status-please&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_status-please)
+[![codecov](https://codecov.io/gh/pleaseai/status-please/branch/main/graph/badge.svg)](https://codecov.io/gh/pleaseai/status-please)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+
 > An open-source, CDN-native **status page** generator — the modern successor to [upptime](https://github.com/upptime/upptime).
 
 `status-please` monitors your services, records their uptime as durable time-series

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/pleaseai/status-please/actions/workflows/ci.yml/badge.svg)](https://github.com/pleaseai/status-please/actions/workflows/ci.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_status-please&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_status-please)
-[![codecov](https://codecov.io/gh/pleaseai/status-please/branch/main/graph/badge.svg)](https://codecov.io/gh/pleaseai/status-please)
+[![codecov](https://codecov.io/gh/pleaseai/status-please/graph/badge.svg)](https://codecov.io/gh/pleaseai/status-please)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
 > An open-source, CDN-native **status page** generator — the modern successor to [upptime](https://github.com/upptime/upptime).


### PR DESCRIPTION
Add a badge row to the README: CI status, SonarCloud Quality Gate, Codecov coverage, and MIT license.

SonarCloud project `pleaseai_status-please` is analyzing in CI; Codecov uploads via OIDC. First PR through the new branch protection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a badge row to the README header showing CI status, SonarCloud Quality Gate for `pleaseai_status-please`, Codecov coverage, and MIT license. This surfaces build health, code quality, coverage, and license at a glance for contributors.

<sup>Written for commit d72104d3114751db31ec8d23c90cb1dc57507ad3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

