### PR TITLE
docs: add Statping, OpenStatus, and CachetHQ to prior art

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,13 @@ Detailed setup will land with the first release — see the [Roadmap](#roadmap).
 - [Statuspage.io](https://www.atlassian.com/software/statuspage) — the reference
   information architecture.
 - [Instatus](https://instatus.com) — static-first delivery and modern design.
+- [statping/statping](https://github.com/statping/statping) — a self-hosted,
+  single-binary status server (Go) with its own monitoring engine, notifiers,
+  and mobile app.
+- [OpenStatus](https://www.openstatus.dev) — open-source synthetic monitoring and
+  status pages, with a globally distributed checker for latency-aware probing.
+- [CachetHQ/Cachet](https://cachethq.io) — a long-standing open-source status page
+  system (PHP/Laravel) centered on incident and component management.
 
 ---
 


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

Adds three prior-art entries to the "Prior art & inspiration" section of README.md: Statping, OpenStatus, and CachetHQ, each with a one-line description and a link.

## Related issue

<!-- none -->

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added or updated, and the suite passes (`bun run test`) <!-- N/A: docs-only change -->
- [x] Lint/format pass (`bun run lint`)
- [x] Documentation updated if behavior changed
- [x] No breaking change, or a `BREAKING CHANGE:` note is included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added three prior-art entries to the README: `statping/statping`, OpenStatus, and `CachetHQ/Cachet`, each with a one-line description and link.

<sup>Written for commit 99bd059f220346baaaf45c0085d042e109430d28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

