### PR TITLE
feat(web): add 90-day uptime timeline per component

### DIFF
--- a/apps/web/src/components/StatusList.tsx
+++ b/apps/web/src/components/StatusList.tsx
@@ -1,5 +1,5 @@
 import type { SiteSummary } from '@status-please/core'
-import { toSeverity } from '@status-please/core'
+import { formatUptime, toSeverity, windowUptime } from '@status-please/core'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
 import {
@@ -9,6 +9,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { UptimeTimeline } from './UptimeTimeline'
 
 const SEVERITY = {
   operational: { label: 'Operational', dot: 'bg-status-operational', badge: 'border-status-operational/40 text-status-operational' },
@@ -19,8 +20,9 @@ const SEVERITY = {
 } as const
 
 /**
- * Component rows for the status page. Interactive (uptime tooltips), so it
- * hydrates as a React island; the rest of the page stays static.
+ * Per-component status cards: name + rolled-up badge, a 90-day uptime timeline,
+ * and the 90-day uptime figure (hover for the 24h/7d/30d breakdown). Interactive
+ * (the breakdown tooltip), so it hydrates as a React island.
  */
 export function StatusList({ summary }: { summary: SiteSummary[] }) {
   return (
@@ -29,34 +31,45 @@ export function StatusList({ summary }: { summary: SiteSummary[] }) {
         {summary.map((site) => {
           const meta = SEVERITY[toSeverity(site.status)]
           return (
-            <div key={site.slug} className="flex items-center justify-between px-5 py-4">
-              <div className="flex items-center gap-3">
-                <span className={cn('inline-block size-2.5 rounded-full', meta.dot)} />
-                <span className="font-medium">{site.name}</span>
+            <div key={site.slug} className="px-5 py-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <span className={cn('inline-block size-2.5 rounded-full', meta.dot)} />
+                  <span className="font-medium">{site.name}</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={(
+                        <span
+                          tabIndex={0}
+                          className="cursor-default rounded-sm text-sm tabular-nums text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        />
+                      )}
+                    >
+                      {formatUptime(windowUptime(site.history))}
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      24h
+                      {' '}
+                      {site.uptimeDay}
+                      {' '}
+                      · 7d
+                      {' '}
+                      {site.uptimeWeek}
+                      {' '}
+                      · 30d
+                      {' '}
+                      {site.uptimeMonth}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Badge variant="outline" className={meta.badge}>
+                    {meta.label}
+                  </Badge>
+                </div>
               </div>
-              <div className="flex items-center gap-3">
-                <Tooltip>
-                  <TooltipTrigger
-                    render={(
-                      <span
-                        tabIndex={0}
-                        className="cursor-default rounded-sm text-sm tabular-nums text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      />
-                    )}
-                  >
-                    {site.uptimeMonth}
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    30-day uptime · avg
-                    {' '}
-                    {site.responseTime}
-                    {' '}
-                    ms
-                  </TooltipContent>
-                </Tooltip>
-                <Badge variant="outline" className={meta.badge}>
-                  {meta.label}
-                </Badge>
+              <div className="mt-3">
+                <UptimeTimeline history={site.history} />
               </div>
             </div>
           )

--- a/apps/web/src/components/StatusList.tsx
+++ b/apps/web/src/components/StatusList.tsx
@@ -30,6 +30,10 @@ export function StatusList({ summary }: { summary: SiteSummary[] }) {
       <Card className="gap-0 divide-y divide-border overflow-hidden py-0">
         {summary.map((site) => {
           const meta = SEVERITY[toSeverity(site.status)]
+          // Guard against stale KV snapshots written before `history` existed.
+          const history = site.history ?? []
+          const uptime90 = formatUptime(windowUptime(history))
+          const breakdown = `Today ${site.uptimeDay} · 7d ${site.uptimeWeek} · 30d ${site.uptimeMonth} · 90d ${uptime90}`
           return (
             <div key={site.slug} className="px-5 py-4">
               <div className="flex items-center justify-between">
@@ -47,21 +51,9 @@ export function StatusList({ summary }: { summary: SiteSummary[] }) {
                         />
                       )}
                     >
-                      {formatUptime(windowUptime(site.history))}
+                      {uptime90}
                     </TooltipTrigger>
-                    <TooltipContent>
-                      24h
-                      {' '}
-                      {site.uptimeDay}
-                      {' '}
-                      · 7d
-                      {' '}
-                      {site.uptimeWeek}
-                      {' '}
-                      · 30d
-                      {' '}
-                      {site.uptimeMonth}
-                    </TooltipContent>
+                    <TooltipContent>{breakdown}</TooltipContent>
                   </Tooltip>
                   <Badge variant="outline" className={meta.badge}>
                     {meta.label}
@@ -69,7 +61,7 @@ export function StatusList({ summary }: { summary: SiteSummary[] }) {
                 </div>
               </div>
               <div className="mt-3">
-                <UptimeTimeline history={site.history} />
+                <UptimeTimeline history={history} />
               </div>
             </div>
           )

--- a/apps/web/src/components/UptimeTimeline.tsx
+++ b/apps/web/src/components/UptimeTimeline.tsx
@@ -1,0 +1,55 @@
+import type { DayStat } from '@status-please/core'
+import { formatUptime, windowUptime } from '@status-please/core'
+import { cn } from '@/lib/utils'
+
+const DAY = {
+  up: { color: 'bg-status-operational', label: 'Operational' },
+  degraded: { color: 'bg-status-degraded', label: 'Degraded' },
+  down: { color: 'bg-status-major', label: 'Outage' },
+  nodata: { color: 'bg-status-nodata', label: 'No data' },
+} as const
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+/** Format an ISO `YYYY-MM-DD` (UTC) as e.g. "Jul 5, 2026" without a date lib. */
+function formatDate(iso: string): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  return `${MONTHS[m - 1]} ${d}, ${y}`
+}
+
+/**
+ * 90-day uptime bar timeline. Each bar carries a native `title` for per-day
+ * detail — cheap and accessible for a dense strip, and it needs no JS, so the
+ * timeline renders as static HTML. Bars flex to fill the width and shrink on
+ * narrow viewports (adaptive), so the full window fits without a scrollbar.
+ */
+export function UptimeTimeline({ history }: { history: DayStat[] }) {
+  const uptime = formatUptime(windowUptime(history))
+  return (
+    <div>
+      <div
+        className="flex h-9 items-stretch gap-px"
+        role="img"
+        aria-label={`90-day uptime history — ${uptime} uptime`}
+      >
+        {history.map((d) => {
+          const meta = DAY[d.status ?? 'nodata']
+          return (
+            <div
+              key={d.date}
+              title={`${formatDate(d.date)} — ${meta.label} · ${formatUptime(d.uptime)}`}
+              className={cn(
+                'min-w-[2px] flex-1 rounded-[1px] transition-opacity hover:opacity-70',
+                meta.color,
+              )}
+            />
+          )
+        })}
+      </div>
+      <div className="mt-1.5 flex items-center justify-between text-xs text-muted-foreground">
+        <span>90 days ago</span>
+        <span>Today</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/UptimeTimeline.tsx
+++ b/apps/web/src/components/UptimeTimeline.tsx
@@ -37,7 +37,7 @@ export function UptimeTimeline({ history }: { history: DayStat[] }) {
           return (
             <div
               key={d.date}
-              title={`${formatDate(d.date)} — ${meta.label} · ${formatUptime(d.uptime)}`}
+              title={`${formatDate(d.date)} — ${meta.label}${d.status !== null ? ` · ${formatUptime(d.uptime)}` : ''}`}
               className={cn(
                 'min-w-[2px] flex-1 rounded-[1px] transition-opacity hover:opacity-70',
                 meta.color,

--- a/apps/web/src/lib/data.ts
+++ b/apps/web/src/lib/data.ts
@@ -1,10 +1,37 @@
-import type { SiteSummary } from '@status-please/core'
+import type { CheckStatus, DayStat, SiteSummary } from '@status-please/core'
 import { env } from 'cloudflare:workers'
 
+/**
+ * Build 90 days of deterministic sample history (oldest → newest, ending
+ * today). A small LCG keyed by `seed` sprinkles occasional degraded/down days
+ * so the demo timeline looks organic without depending on `Math.random`.
+ */
+function sampleHistory(seed: number): DayStat[] {
+  const days: DayStat[] = []
+  const today = new Date()
+  for (let i = 89; i >= 0; i--) {
+    const d = new Date(today)
+    d.setUTCDate(d.getUTCDate() - i)
+    const r = ((i + 1) * 9301 + seed * 49297) % 233280 / 233280
+    let status: CheckStatus = 'up'
+    let uptime = 1
+    if (r > 0.97) {
+      status = 'down'
+      uptime = 0.62
+    }
+    else if (r > 0.92) {
+      status = 'degraded'
+      uptime = 0.98
+    }
+    days.push({ date: d.toISOString().slice(0, 10), status, uptime })
+  }
+  return days
+}
+
 const SAMPLE: SiteSummary[] = [
-  { slug: 'website', name: 'Website', status: 'up', responseTime: 142, uptimeDay: '100%', uptimeWeek: '99.98%', uptimeMonth: '99.95%' },
-  { slug: 'api', name: 'API', status: 'degraded', responseTime: 2310, uptimeDay: '99.2%', uptimeWeek: '99.7%', uptimeMonth: '99.8%' },
-  { slug: 'cdn', name: 'CDN', status: 'up', responseTime: 38, uptimeDay: '100%', uptimeWeek: '100%', uptimeMonth: '100%' },
+  { slug: 'website', name: 'Website', status: 'up', responseTime: 142, uptimeDay: '100%', uptimeWeek: '99.98%', uptimeMonth: '99.95%', history: sampleHistory(3) },
+  { slug: 'api', name: 'API', status: 'degraded', responseTime: 2310, uptimeDay: '99.2%', uptimeWeek: '99.7%', uptimeMonth: '99.8%', history: sampleHistory(11) },
+  { slug: 'cdn', name: 'CDN', status: 'up', responseTime: 38, uptimeDay: '100%', uptimeWeek: '100%', uptimeMonth: '100%', history: sampleHistory(7) },
 ]
 
 /**

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -31,7 +31,6 @@ Astro.response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-re
       <StatusList summary={summary} client:visible />
 
       {/*
-        TODO(uptime-bars): 90-day adaptive bar timeline per component.
         TODO(incidents): incident timeline (Investigating → Resolved).
         TODO(charts): response-time graphs via `bunx shadcn@latest add chart`.
       */}

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -36,6 +36,7 @@
   --color-status-partial: var(--status-partial);
   --color-status-major: var(--status-major);
   --color-status-maintenance: var(--status-maintenance);
+  --color-status-nodata: var(--status-nodata);
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/apps/worker/schema.sql
+++ b/apps/worker/schema.sql
@@ -13,6 +13,10 @@ CREATE TABLE IF NOT EXISTS checks (
 
 CREATE INDEX IF NOT EXISTS idx_checks_slug_time ON checks (slug, checked_at DESC);
 
+-- checked_at-first index so the 90-day history aggregate (a range scan across
+-- all slugs) is sargable and does not degrade as the table grows.
+CREATE INDEX IF NOT EXISTS idx_checks_time ON checks (checked_at);
+
 -- Incident lifecycle: Investigating → Identified → Monitoring → Resolved.
 CREATE TABLE IF NOT EXISTS incidents (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -98,6 +98,9 @@ interface DayRow {
 async function readHistory(env: Env): Promise<Map<string, Map<string, DayStat>>> {
   const since = new Date()
   since.setUTCDate(since.getUTCDate() - (HISTORY_DAYS - 1))
+  since.setUTCHours(0, 0, 0, 0)
+  // Filter on the raw ISO `checked_at` (sargable via idx_checks_time) rather
+  // than `date(checked_at)`, which would wrap the column and skip the index.
   const rows = await env.DB.prepare(
     `SELECT slug,
             date(checked_at) AS day,
@@ -106,9 +109,9 @@ async function readHistory(env: Env): Promise<Map<string, Map<string, DayStat>>>
             SUM(status = 'down') AS down,
             COUNT(*) AS total
      FROM checks
-     WHERE date(checked_at) >= ?
+     WHERE checked_at >= ?
      GROUP BY slug, day`,
-  ).bind(since.toISOString().slice(0, 10)).all<DayRow>()
+  ).bind(since.toISOString()).all<DayRow>()
 
   const bySlug = new Map<string, Map<string, DayStat>>()
   for (const row of rows.results) {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,7 +1,9 @@
-import type { CheckResult, SiteSummary, StatusConfig } from '@status-please/core'
+import type { CheckResult, CheckStatus, DayStat, SiteSummary, StatusConfig } from '@status-please/core'
 import type { Env } from './env'
-import { checkSite, parseConfig } from '@status-please/core'
+import { checkSite, formatUptime, parseConfig, windowUptime } from '@status-please/core'
 import { KV_KEYS } from './env'
+
+const HISTORY_DAYS = 90
 
 /**
  * Cron entrypoint. Runs on the schedule in wrangler.jsonc: check every site,
@@ -61,18 +63,72 @@ async function readSummary(env: Env): Promise<Map<string, string>> {
 /** Overwrite the snapshot the status page reads at the edge. */
 async function writeSummary(env: Env, config: StatusConfig, results: CheckResult[]): Promise<void> {
   const bySlug = new Map(results.map(r => [r.slug, r]))
+  const historyBySlug = await readHistory(env)
   const summary: SiteSummary[] = config.sites.map((site) => {
     const r = bySlug.get(site.slug)
+    const history = denseHistory(historyBySlug.get(site.slug))
     return {
       slug: site.slug,
       name: site.name,
       status: r?.status ?? 'down',
       responseTime: r?.responseTime ?? 0,
-      // TODO(uptime): compute trailing windows from the D1 `checks` table.
-      uptimeDay: '—',
-      uptimeWeek: '—',
-      uptimeMonth: '—',
+      // Trailing windows are the tail slices of the same 90-day history.
+      uptimeDay: formatUptime(windowUptime(history.slice(-1))),
+      uptimeWeek: formatUptime(windowUptime(history.slice(-7))),
+      uptimeMonth: formatUptime(windowUptime(history.slice(-30))),
+      history,
     }
   })
   await env.STATUS_KV.put(KV_KEYS.summary, JSON.stringify(summary))
+}
+
+interface DayRow {
+  slug: string
+  day: string
+  up: number
+  degraded: number
+  down: number
+  total: number
+}
+
+/**
+ * Aggregate the D1 `checks` table into one row per (slug, day) for the last
+ * {@link HISTORY_DAYS} days: the worst status of the day and its uptime ratio.
+ */
+async function readHistory(env: Env): Promise<Map<string, Map<string, DayStat>>> {
+  const since = new Date()
+  since.setUTCDate(since.getUTCDate() - (HISTORY_DAYS - 1))
+  const rows = await env.DB.prepare(
+    `SELECT slug,
+            date(checked_at) AS day,
+            SUM(status = 'up') AS up,
+            SUM(status = 'degraded') AS degraded,
+            SUM(status = 'down') AS down,
+            COUNT(*) AS total
+     FROM checks
+     WHERE date(checked_at) >= ?
+     GROUP BY slug, day`,
+  ).bind(since.toISOString().slice(0, 10)).all<DayRow>()
+
+  const bySlug = new Map<string, Map<string, DayStat>>()
+  for (const row of rows.results) {
+    const status: CheckStatus = row.down > 0 ? 'down' : row.degraded > 0 ? 'degraded' : 'up'
+    const days = bySlug.get(row.slug) ?? new Map<string, DayStat>()
+    days.set(row.day, { date: row.day, status, uptime: row.total ? row.up / row.total : 1 })
+    bySlug.set(row.slug, days)
+  }
+  return bySlug
+}
+
+/** Expand sparse per-day rows into a dense 90-entry window (oldest → newest). */
+function denseHistory(days: Map<string, DayStat> | undefined): DayStat[] {
+  const out: DayStat[] = []
+  const today = new Date()
+  for (let i = HISTORY_DAYS - 1; i >= 0; i--) {
+    const d = new Date(today)
+    d.setUTCDate(d.getUTCDate() - i)
+    const date = d.toISOString().slice(0, 10)
+    out.push(days?.get(date) ?? { date, status: null, uptime: 1 })
+  }
+  return out
 }

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,0 +1,58 @@
+import type { DayStat } from './types'
+import { describe, expect, it } from 'bun:test'
+import { formatUptime, overallSeverity, toSeverity, windowUptime } from './types'
+
+function day(status: DayStat['status'], uptime: number): DayStat {
+  return { date: '2026-01-01', status, uptime }
+}
+
+describe('toSeverity', () => {
+  it('maps check statuses to display severities', () => {
+    expect(toSeverity('up')).toBe('operational')
+    expect(toSeverity('degraded')).toBe('degraded')
+    expect(toSeverity('down')).toBe('major_outage')
+  })
+})
+
+describe('overallSeverity', () => {
+  it('is operational when everything is up', () => {
+    expect(overallSeverity(['up', 'up'])).toBe('operational')
+  })
+
+  it('picks the worst status (down beats degraded)', () => {
+    expect(overallSeverity(['up', 'degraded', 'down'])).toBe('major_outage')
+    expect(overallSeverity(['up', 'degraded'])).toBe('degraded')
+  })
+
+  it('is operational for an empty list', () => {
+    expect(overallSeverity([])).toBe('operational')
+  })
+})
+
+describe('windowUptime', () => {
+  it('averages the uptime of days that have data', () => {
+    expect(windowUptime([day('up', 1), day('degraded', 0.98)])).toBeCloseTo(0.99)
+  })
+
+  it('ignores no-data days', () => {
+    // Only the two data days count; the null day is excluded.
+    expect(windowUptime([day('up', 1), day(null, 1), day('down', 0)])).toBeCloseTo(0.5)
+  })
+
+  it('returns 1 when the window is empty or entirely no-data', () => {
+    expect(windowUptime([])).toBe(1)
+    expect(windowUptime([day(null, 1), day(null, 1)])).toBe(1)
+  })
+})
+
+describe('formatUptime', () => {
+  it('formats a ratio as a two-decimal percentage', () => {
+    expect(formatUptime(0.9998)).toBe('99.98%')
+    expect(formatUptime(0.9)).toBe('90.00%')
+  })
+
+  it('collapses a rounded 100 to "100%"', () => {
+    expect(formatUptime(1)).toBe('100%')
+    expect(formatUptime(0.99999)).toBe('100%')
+  })
+})

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -23,6 +23,16 @@ export interface CheckResult {
   error?: string
 }
 
+/** One calendar day's rolled-up outcome, for the 90-day timeline. */
+export interface DayStat {
+  /** ISO date, `YYYY-MM-DD` (UTC). */
+  date: string
+  /** Worst status seen that day; `null` when no checks ran (no data). */
+  status: CheckStatus | null
+  /** Fraction of checks that were `up` (0..1). `1` for a no-data day. */
+  uptime: number
+}
+
 /** Aggregated current state for one site, served to the status page. */
 export interface SiteSummary {
   slug: string
@@ -33,6 +43,8 @@ export interface SiteSummary {
   uptimeDay: string
   uptimeWeek: string
   uptimeMonth: string
+  /** Per-day history, oldest → newest, up to 90 entries. */
+  history: DayStat[]
 }
 
 /** Map CheckStatus → the display severity used by the banner and badges. */
@@ -56,4 +68,23 @@ export function overallSeverity(statuses: CheckStatus[]): Severity {
     return 'degraded'
   }
   return 'operational'
+}
+
+/**
+ * Average uptime over a day-stat window, ignoring no-data days. Returns `1`
+ * when the window is empty or entirely no-data (nothing to report against).
+ */
+export function windowUptime(history: DayStat[]): number {
+  const days = history.filter(d => d.status !== null)
+  if (days.length === 0) {
+    return 1
+  }
+  return days.reduce((sum, d) => sum + d.uptime, 0) / days.length
+}
+
+/** Format an uptime ratio (0..1) as a display percentage, e.g. "99.98%". */
+export function formatUptime(ratio: number): string {
+  const pct = ratio * 100
+  // Avoid "100.00%" when a rounded value reaches 100.
+  return pct >= 99.995 ? '100%' : `${pct.toFixed(2)}%`
 }


### PR DESCRIPTION
Adds the classic status-page **uptime bar timeline** (statuspage.io / upptime style) — one of the original design references for this project.

## What
- **90 daily bars per component**, each colored by that day's worst status (operational / degraded / outage), with a **no-data grey** for gaps.
- Each bar has a native `title` (`Jul 5, 2026 — Operational · 100%`) — cheap, accessible, and **0 JS** for a dense strip (avoids ~270 tooltip roots). Bars flex to fill width and shrink on mobile (adaptive), so the full 90-day window fits with no scrollbar.
- The 90-day uptime figure sits by the badge; hover for the **24h / 7d / 30d breakdown** (shadcn Tooltip).

## Layers
- **core**: `DayStat` type + `SiteSummary.history`; `windowUptime()` / `formatUptime()` helpers (unit-tested) roll a day-stat window into an uptime figure.
- **worker** (the data producer): aggregates the D1 `checks` table into one row per `(slug, day)` for 90 days (worst status + uptime ratio), densifies gaps as no-data, and derives the 24h/7d/30d windows as tail slices — **removes the `'—'` placeholders**.
- **web**: `UptimeTimeline` component + `StatusList` restructured into per-component cards; `--color-status-nodata` token added.

## Verification
Dev render: 3×90 bars, organic colour spread (252 up / 16 degraded / 12 outage), formatted day titles, captions. `typecheck` (0 errors, web + worker), `lint`, **14 tests**, `build` all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 90-day uptime bar timeline per component, colored by the day’s worst status with a no‑data grey. Shows a 90‑day uptime figure with a Today/7d/30d/90d breakdown.

- **New Features**
  - `UptimeTimeline` (web): 90 responsive bars per component with native `title` (date · status · uptime); fits without scrolling.
  - Worker: aggregates D1 `checks` into per‑day stats for the last 90 days, densifies gaps as no‑data, and derives trailing windows (no more placeholders).
  - Core (`@status-please/core`): adds `DayStat`, `SiteSummary.history`, and `windowUptime()`/`formatUptime()` with tests.
  - Status UI: `StatusList` shows name + badge, the timeline, and a headline 90‑day uptime; hover reveals Today/7d/30d/90d.

- **Refactors**
  - UI polish: guard `site.history` for older KV snapshots; no‑data bars now title as “No data” (no fake “· 100%”); relabel “24h” → “Today”.
  - Worker perf: filter history on raw ISO `checked_at` (sargable) and add `idx_checks_time` to keep the 90‑day aggregate fast as `checks` grows.

<sup>Written for commit 1e9507cf7be0844874dd4a37cd69335288203fe2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

