### PR TITLE
feat: incident timeline

### DIFF
--- a/apps/web/src/components/IncidentList.tsx
+++ b/apps/web/src/components/IncidentList.tsx
@@ -1,0 +1,106 @@
+import type { Incident, IncidentState, Severity } from '@status-please/core'
+import { isActive, orderedUpdates, relativeTime } from '@status-please/core'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+const SEVERITY = {
+  operational: { label: 'Operational', badge: 'border-status-operational/40 text-status-operational' },
+  degraded: { label: 'Degraded', badge: 'border-status-degraded/40 text-status-degraded' },
+  partial_outage: { label: 'Partial Outage', badge: 'border-status-partial/40 text-status-partial' },
+  major_outage: { label: 'Major Outage', badge: 'border-status-major/40 text-status-major' },
+  maintenance: { label: 'Maintenance', badge: 'border-status-maintenance/40 text-status-maintenance' },
+} satisfies Record<Severity, { label: string, badge: string }>
+
+const STATE = {
+  investigating: { label: 'Investigating', badge: 'border-status-major/40 text-status-major' },
+  identified: { label: 'Identified', badge: 'border-status-partial/40 text-status-partial' },
+  monitoring: { label: 'Monitoring', badge: 'border-status-maintenance/40 text-status-maintenance' },
+  resolved: { label: 'Resolved', badge: 'border-status-operational/40 text-status-operational' },
+} satisfies Record<IncidentState, { label: string, badge: string }>
+
+/** Sort incidents by recency: active ones by start, resolved ones by resolution. */
+function byRecency(a: Incident, b: Incident): number {
+  const at = new Date(a.resolvedAt ?? a.startedAt).getTime()
+  const bt = new Date(b.resolvedAt ?? b.startedAt).getTime()
+  return bt - at
+}
+
+/** One incident card: title + severity badge, then its chronological updates. */
+function IncidentCard({ incident }: { incident: Incident }) {
+  const sev = SEVERITY[incident.severity]
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <CardTitle>{incident.title}</CardTitle>
+          <Badge variant="outline" className={cn('shrink-0', sev.badge)}>
+            {sev.label}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <ol className="space-y-4 border-l border-border pl-4">
+          {orderedUpdates(incident).map((u) => {
+            const state = STATE[u.state]
+            return (
+              <li key={u.id}>
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline" className={state.badge}>
+                    {state.label}
+                  </Badge>
+                  <time className="text-xs tabular-nums text-muted-foreground" dateTime={u.createdAt}>
+                    {relativeTime(u.createdAt)}
+                  </time>
+                </div>
+                <p className="mt-1 text-sm text-muted-foreground">{u.body}</p>
+              </li>
+            )
+          })}
+        </ol>
+      </CardContent>
+    </Card>
+  )
+}
+
+/**
+ * Incident timeline: active incidents surface first, recently resolved ones
+ * below a muted divider. Each card lists the incident's updates in chronological
+ * order (state badge + body + relative time). Static — it renders to HTML with
+ * 0 JS (relative times are computed at edge render). Calm empty state when none.
+ */
+export function IncidentList({ incidents }: { incidents: Incident[] }) {
+  const active = incidents.filter(isActive).sort(byRecency)
+  const resolved = incidents.filter(i => !isActive(i)).sort(byRecency)
+
+  if (active.length === 0 && resolved.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-6 text-center text-sm text-muted-foreground">
+          No incidents reported in the last 90 days.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {active.map(incident => (
+        <IncidentCard key={incident.id} incident={incident} />
+      ))}
+
+      {resolved.length > 0 && (
+        <>
+          {active.length > 0 && (
+            <p className="pt-2 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              Recently resolved
+            </p>
+          )}
+          {resolved.map(incident => (
+            <IncidentCard key={incident.id} incident={incident} />
+          ))}
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/lib/data.ts
+++ b/apps/web/src/lib/data.ts
@@ -1,4 +1,4 @@
-import type { CheckStatus, DayStat, SiteSummary } from '@status-please/core'
+import type { CheckStatus, DayStat, Incident, SiteSummary } from '@status-please/core'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -49,4 +49,52 @@ export async function getSummary(): Promise<SiteSummary[]> {
     }
   }
   return SAMPLE
+}
+
+/** ISO timestamp `hours` before now — keeps sample incidents fresh for `astro dev`. */
+function hoursAgo(hours: number): string {
+  return new Date(Date.now() - hours * 3600_000).toISOString()
+}
+
+const SAMPLE_INCIDENTS: Incident[] = [
+  {
+    id: 2,
+    slug: 'api',
+    title: 'Elevated API error rates',
+    severity: 'degraded',
+    startedAt: hoursAgo(2),
+    resolvedAt: null,
+    updates: [
+      { id: 3, incidentId: 2, state: 'investigating', body: 'We are investigating a spike in 5xx responses on the API.', createdAt: hoursAgo(2) },
+      { id: 4, incidentId: 2, state: 'identified', body: 'A slow upstream dependency has been identified as the cause. A fix is being rolled out.', createdAt: hoursAgo(1) },
+    ],
+  },
+  {
+    id: 1,
+    slug: 'website',
+    title: 'Intermittent connection timeouts',
+    severity: 'major_outage',
+    startedAt: hoursAgo(52),
+    resolvedAt: hoursAgo(48),
+    updates: [
+      { id: 1, incidentId: 1, state: 'investigating', body: 'Some visitors are seeing connection timeouts loading the website.', createdAt: hoursAgo(52) },
+      { id: 2, incidentId: 1, state: 'monitoring', body: 'We restarted the affected edge nodes and are monitoring recovery.', createdAt: hoursAgo(50) },
+      { id: 5, incidentId: 1, state: 'resolved', body: 'Timeouts have cleared and traffic is fully healthy. The incident is resolved.', createdAt: hoursAgo(48) },
+    ],
+  },
+]
+
+/**
+ * Read the incident timeline the check Worker writes to KV. Falls back to sample
+ * incidents so `astro dev` renders a realistic timeline without Cloudflare bindings.
+ */
+export async function getIncidents(): Promise<Incident[]> {
+  const kv = env.STATUS_KV
+  if (kv) {
+    const raw = await kv.get('incidents')
+    if (raw) {
+      return JSON.parse(raw) as Incident[]
+    }
+  }
+  return SAMPLE_INCIDENTS
 }

--- a/apps/web/src/lib/data.ts
+++ b/apps/web/src/lib/data.ts
@@ -56,33 +56,37 @@ function hoursAgo(hours: number): string {
   return new Date(Date.now() - hours * 3600_000).toISOString()
 }
 
-const SAMPLE_INCIDENTS: Incident[] = [
-  {
-    id: 2,
-    slug: 'api',
-    title: 'Elevated API error rates',
-    severity: 'degraded',
-    startedAt: hoursAgo(2),
-    resolvedAt: null,
-    updates: [
-      { id: 3, incidentId: 2, state: 'investigating', body: 'We are investigating a spike in 5xx responses on the API.', createdAt: hoursAgo(2) },
-      { id: 4, incidentId: 2, state: 'identified', body: 'A slow upstream dependency has been identified as the cause. A fix is being rolled out.', createdAt: hoursAgo(1) },
-    ],
-  },
-  {
-    id: 1,
-    slug: 'website',
-    title: 'Intermittent connection timeouts',
-    severity: 'major_outage',
-    startedAt: hoursAgo(52),
-    resolvedAt: hoursAgo(48),
-    updates: [
-      { id: 1, incidentId: 1, state: 'investigating', body: 'Some visitors are seeing connection timeouts loading the website.', createdAt: hoursAgo(52) },
-      { id: 2, incidentId: 1, state: 'monitoring', body: 'We restarted the affected edge nodes and are monitoring recovery.', createdAt: hoursAgo(50) },
-      { id: 5, incidentId: 1, state: 'resolved', body: 'Timeouts have cleared and traffic is fully healthy. The incident is resolved.', createdAt: hoursAgo(48) },
-    ],
-  },
-]
+// A factory (not a module-level const) so `hoursAgo()` is evaluated per call —
+// relative times stay fresh across a long-running `astro dev` session.
+function sampleIncidents(): Incident[] {
+  return [
+    {
+      id: 2,
+      slug: 'api',
+      title: 'Elevated API error rates',
+      severity: 'degraded',
+      startedAt: hoursAgo(2),
+      resolvedAt: null,
+      updates: [
+        { id: 3, incidentId: 2, state: 'investigating', body: 'We are investigating a spike in 5xx responses on the API.', createdAt: hoursAgo(2) },
+        { id: 4, incidentId: 2, state: 'identified', body: 'A slow upstream dependency has been identified as the cause. A fix is being rolled out.', createdAt: hoursAgo(1) },
+      ],
+    },
+    {
+      id: 1,
+      slug: 'website',
+      title: 'Intermittent connection timeouts',
+      severity: 'major_outage',
+      startedAt: hoursAgo(52),
+      resolvedAt: hoursAgo(48),
+      updates: [
+        { id: 1, incidentId: 1, state: 'investigating', body: 'Some visitors are seeing connection timeouts loading the website.', createdAt: hoursAgo(52) },
+        { id: 2, incidentId: 1, state: 'monitoring', body: 'We restarted the affected edge nodes and are monitoring recovery.', createdAt: hoursAgo(50) },
+        { id: 5, incidentId: 1, state: 'resolved', body: 'Timeouts have cleared and traffic is fully healthy. The incident is resolved.', createdAt: hoursAgo(48) },
+      ],
+    },
+  ]
+}
 
 /**
  * Read the incident timeline the check Worker writes to KV. Falls back to sample
@@ -96,5 +100,5 @@ export async function getIncidents(): Promise<Incident[]> {
       return JSON.parse(raw) as Incident[]
     }
   }
-  return SAMPLE_INCIDENTS
+  return sampleIncidents()
 }

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -34,7 +34,7 @@ Astro.response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-re
 
       {/* Static: relative times are computed at edge render, so 0 JS ships. */}
       <section class="mt-10">
-        <h2 class="mb-4 text-sm font-medium tracking-wide text-muted-foreground uppercase">Past Incidents</h2>
+        <h2 class="mb-4 text-sm font-medium tracking-wide text-muted-foreground uppercase">Incidents</h2>
         <IncidentList incidents={incidents} />
       </section>
 

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -1,12 +1,14 @@
 ---
 import { overallSeverity } from '@status-please/core'
+import { IncidentList } from '../components/IncidentList'
 import { StatusBanner } from '../components/StatusBanner'
 import { StatusList } from '../components/StatusList'
-import { getSummary } from '../lib/data'
+import { getIncidents, getSummary } from '../lib/data'
 import '../styles/global.css'
 
 const summary = await getSummary()
 const overall = overallSeverity(summary.map(s => s.status))
+const incidents = await getIncidents()
 
 // Render at the edge, cache the result, and let Workers Cache serve subsequent
 // hits. The check Worker purges by tag on a status change (see wrangler.jsonc).
@@ -30,8 +32,13 @@ Astro.response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-re
       {/* Interactive (uptime tooltips): hydrates as a React island. */}
       <StatusList summary={summary} client:visible />
 
+      {/* Static: relative times are computed at edge render, so 0 JS ships. */}
+      <section class="mt-10">
+        <h2 class="mb-4 text-sm font-medium tracking-wide text-muted-foreground uppercase">Past Incidents</h2>
+        <IncidentList incidents={incidents} />
+      </section>
+
       {/*
-        TODO(incidents): incident timeline (Investigating → Resolved).
         TODO(charts): response-time graphs via `bunx shadcn@latest add chart`.
       */}
 

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -11,4 +11,6 @@ export const KV_KEYS = {
   config: 'config',
   /** JSON array of SiteSummary — the whole dashboard in one read. */
   summary: 'summary',
+  /** JSON array of Incident — the incident timeline in one read. */
+  incidents: 'incidents',
 } as const

--- a/packages/core/src/incidents.test.ts
+++ b/packages/core/src/incidents.test.ts
@@ -30,6 +30,11 @@ describe('orderedUpdates', () => {
     // Original array order is preserved (non-mutating).
     expect(updates.map(u => u.id)).toEqual([2, 1, 3])
   })
+
+  it('returns [] when a KV record is missing updates (no crash)', () => {
+    const broken = { ...incident([]), updates: undefined } as unknown as Incident
+    expect(orderedUpdates(broken)).toEqual([])
+  })
 })
 
 describe('latestUpdate', () => {
@@ -89,5 +94,9 @@ describe('relativeTime', () => {
     expect(relativeTime('2026-01-01T23:45:00.000Z', now)).toBe('15m ago')
     expect(relativeTime('2026-01-01T21:00:00.000Z', now)).toBe('3h ago')
     expect(relativeTime('2025-12-30T00:00:00.000Z', now)).toBe('3d ago')
+  })
+
+  it('falls back to the raw string for an unparseable timestamp', () => {
+    expect(relativeTime('not-a-date', now)).toBe('not-a-date')
   })
 })

--- a/packages/core/src/incidents.test.ts
+++ b/packages/core/src/incidents.test.ts
@@ -1,0 +1,93 @@
+import type { Incident, IncidentState, IncidentUpdate } from './incidents'
+import { describe, expect, it } from 'bun:test'
+import { isActive, latestState, latestUpdate, orderedUpdates, relativeTime } from './incidents'
+
+function update(id: number, state: IncidentState, createdAt: string): IncidentUpdate {
+  return { id, incidentId: 1, state, body: `${state} at ${createdAt}`, createdAt }
+}
+
+function incident(updates: IncidentUpdate[], resolvedAt: string | null = null): Incident {
+  return {
+    id: 1,
+    slug: 'api',
+    title: 'Elevated error rates',
+    severity: 'major_outage',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    resolvedAt,
+    updates,
+  }
+}
+
+describe('orderedUpdates', () => {
+  it('sorts updates oldest → newest without mutating the input', () => {
+    const updates = [
+      update(2, 'identified', '2026-01-01T02:00:00.000Z'),
+      update(1, 'investigating', '2026-01-01T01:00:00.000Z'),
+      update(3, 'resolved', '2026-01-01T03:00:00.000Z'),
+    ]
+    const ordered = orderedUpdates(incident(updates))
+    expect(ordered.map(u => u.id)).toEqual([1, 2, 3])
+    // Original array order is preserved (non-mutating).
+    expect(updates.map(u => u.id)).toEqual([2, 1, 3])
+  })
+})
+
+describe('latestUpdate', () => {
+  it('returns the most recent update', () => {
+    const updates = [
+      update(1, 'investigating', '2026-01-01T01:00:00.000Z'),
+      update(2, 'monitoring', '2026-01-01T02:00:00.000Z'),
+    ]
+    expect(latestUpdate(incident(updates))?.id).toBe(2)
+  })
+
+  it('is undefined when there are no updates', () => {
+    expect(latestUpdate(incident([]))).toBeUndefined()
+  })
+})
+
+describe('latestState', () => {
+  it('is the state of the latest update', () => {
+    const updates = [
+      update(1, 'investigating', '2026-01-01T01:00:00.000Z'),
+      update(2, 'monitoring', '2026-01-01T02:00:00.000Z'),
+    ]
+    expect(latestState(incident(updates))).toBe('monitoring')
+  })
+
+  it('falls back to resolved/investigating when there are no updates', () => {
+    expect(latestState(incident([], '2026-01-01T04:00:00.000Z'))).toBe('resolved')
+    expect(latestState(incident([]))).toBe('investigating')
+  })
+})
+
+describe('isActive', () => {
+  it('is active while unresolved and the latest state is not resolved', () => {
+    const updates = [update(1, 'identified', '2026-01-01T01:00:00.000Z')]
+    expect(isActive(incident(updates))).toBe(true)
+  })
+
+  it('is inactive once resolvedAt is set', () => {
+    const updates = [update(1, 'resolved', '2026-01-01T03:00:00.000Z')]
+    expect(isActive(incident(updates, '2026-01-01T03:00:00.000Z'))).toBe(false)
+  })
+
+  it('is inactive when the latest update is resolved even without resolvedAt', () => {
+    const updates = [update(1, 'resolved', '2026-01-01T03:00:00.000Z')]
+    expect(isActive(incident(updates))).toBe(false)
+  })
+})
+
+describe('relativeTime', () => {
+  const now = new Date('2026-01-02T00:00:00.000Z').getTime()
+
+  it('reports seconds as "just now"', () => {
+    expect(relativeTime('2026-01-01T23:59:30.000Z', now)).toBe('just now')
+  })
+
+  it('reports minutes, hours, and days', () => {
+    expect(relativeTime('2026-01-01T23:45:00.000Z', now)).toBe('15m ago')
+    expect(relativeTime('2026-01-01T21:00:00.000Z', now)).toBe('3h ago')
+    expect(relativeTime('2025-12-30T00:00:00.000Z', now)).toBe('3d ago')
+  })
+})

--- a/packages/core/src/incidents.ts
+++ b/packages/core/src/incidents.ts
@@ -38,7 +38,9 @@ export interface Incident {
 
 /** An incident's updates in chronological order (oldest → newest), non-mutating. */
 export function orderedUpdates(incident: Incident): IncidentUpdate[] {
-  return [...incident.updates].sort(
+  // Defensive against a KV payload missing `updates` (only type-asserted, not
+  // validated) — a bad record must not crash the SSR render.
+  return [...(incident.updates ?? [])].sort(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
   )
 }
@@ -70,7 +72,11 @@ export function isActive(incident: Incident): boolean {
  * `now` is injectable so callers and tests stay deterministic.
  */
 export function relativeTime(iso: string, now: number = Date.now()): string {
-  const diffSec = Math.floor((now - new Date(iso).getTime()) / 1000)
+  const ts = new Date(iso).getTime()
+  if (Number.isNaN(ts)) {
+    return iso
+  }
+  const diffSec = Math.floor((now - ts) / 1000)
   if (diffSec < 60) {
     return 'just now'
   }

--- a/packages/core/src/incidents.ts
+++ b/packages/core/src/incidents.ts
@@ -1,0 +1,87 @@
+import type { Severity } from './types'
+
+/** Lifecycle state of an incident, mirrored by `incident_updates.state` in D1. */
+export type IncidentState = 'investigating' | 'identified' | 'monitoring' | 'resolved'
+
+/**
+ * One post in an incident's timeline (a row of `incident_updates`). Each update
+ * moves — or reaffirms — the lifecycle state and carries a human-readable body.
+ */
+export interface IncidentUpdate {
+  id: number
+  /** FK to the owning {@link Incident}. */
+  incidentId: number
+  state: IncidentState
+  /** Operator message shown to readers. */
+  body: string
+  /** ISO-8601 timestamp of when the update was posted. */
+  createdAt: string
+}
+
+/**
+ * An incident and its timeline (a row of `incidents` plus its `incident_updates`).
+ * `resolvedAt` is `null` while the incident is ongoing.
+ */
+export interface Incident {
+  id: number
+  /** Slug of the affected site (matches `SiteSummary.slug`). */
+  slug: string
+  title: string
+  /** Display severity, reusing the page's severity palette. */
+  severity: Severity
+  /** ISO-8601 timestamp of when the incident began. */
+  startedAt: string
+  /** ISO-8601 timestamp of resolution, or `null` while ongoing. */
+  resolvedAt: string | null
+  updates: IncidentUpdate[]
+}
+
+/** An incident's updates in chronological order (oldest → newest), non-mutating. */
+export function orderedUpdates(incident: Incident): IncidentUpdate[] {
+  return [...incident.updates].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  )
+}
+
+/** The most recent update, or `undefined` when the incident has none. */
+export function latestUpdate(incident: Incident): IncidentUpdate | undefined {
+  return orderedUpdates(incident).at(-1)
+}
+
+/**
+ * The incident's current lifecycle state: the state of its latest update, or —
+ * when it has no updates — `resolved` if `resolvedAt` is set, else `investigating`.
+ */
+export function latestState(incident: Incident): IncidentState {
+  const last = latestUpdate(incident)
+  if (last) {
+    return last.state
+  }
+  return incident.resolvedAt !== null ? 'resolved' : 'investigating'
+}
+
+/** True while the incident is ongoing (not yet resolved). */
+export function isActive(incident: Incident): boolean {
+  return incident.resolvedAt === null && latestState(incident) !== 'resolved'
+}
+
+/**
+ * Format an ISO timestamp as a short relative string (e.g. "5m ago", "3h ago").
+ * `now` is injectable so callers and tests stay deterministic.
+ */
+export function relativeTime(iso: string, now: number = Date.now()): string {
+  const diffSec = Math.floor((now - new Date(iso).getTime()) / 1000)
+  if (diffSec < 60) {
+    return 'just now'
+  }
+  const min = Math.floor(diffSec / 60)
+  if (min < 60) {
+    return `${min}m ago`
+  }
+  const hr = Math.floor(min / 60)
+  if (hr < 24) {
+    return `${hr}h ago`
+  }
+  const day = Math.floor(hr / 24)
+  return `${day}d ago`
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './check'
 export * from './config'
+export * from './incidents'
 export * from './types'


### PR DESCRIPTION
## What

Adds an incident lifecycle timeline (Investigating → Identified → Monitoring → Resolved), replacing the `TODO(incidents)` placeholder in `index.astro`. Active incidents surface prominently; recently resolved ones sit below. Each card shows the title, a severity badge (status-token color), and its chronological updates (state badge + body + relative time). Calm empty state when there are none.

## Layers

- **core** (`packages/core/src/incidents.ts`): `IncidentState`, `IncidentUpdate`, `Incident` types aligned to the D1 `incidents` + `incident_updates` schema. Pure helpers: `orderedUpdates`, `latestUpdate`, `latestState`, `isActive` (= not resolved), `relativeTime`. Unit-tested in `incidents.test.ts` (the coverage-gated package) and re-exported from `index.ts`.
- **web** (`apps/web/src/components/IncidentList.tsx`): shadcn Card/Badge, severity + state colors mapped to the `status-*` design tokens, `cn()`. Static (0 JS) — relative times are computed at edge render.
- **data** (`apps/web/src/lib/data.ts`): `getIncidents()` reads KV key `incidents` with a realistic sample fallback (1 active multi-update + 1 resolved multi-update incident) so `astro dev` renders without bindings.
- **index.astro**: new "Past Incidents" section below the component status list.
- **worker** (`apps/worker/src/env.ts`): registered the `incidents` KV key alongside `config`/`summary`.

## Verification

- `bun run typecheck` — 0 errors
- `bun run lint` — clean
- `bun test` — 24 pass / 0 fail
- `cd apps/web && bunx astro build` — build complete

Do not merge yet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an incident lifecycle timeline to the status page, replacing the placeholder. Active incidents show first; recently resolved ones appear below with clear state/severity badges and relative times.

- New Features
  - Core: new `incidents` module in `@status-please/core` with types and helpers (`orderedUpdates`, `latestUpdate`, `latestState`, `isActive`, `relativeTime`), re-exported and unit tested.
  - Web: `IncidentList` renders a static (0 JS) timeline with chronological updates, badges, and a calm empty state.
  - Data: `getIncidents()` reads KV key `incidents`, with a sample factory used in `astro dev` so relative times stay fresh.
  - Page: adds an “Incidents” section to `index.astro`.
  - Worker: registers the `incidents` KV key.

- Bug Fixes
  - Core: harden helpers against bad KV payloads — `orderedUpdates` tolerates missing `updates`, and `relativeTime` returns the raw string for unparseable timestamps; tests cover both.

<sup>Written for commit 3046487cb61855fa49cfd96c5c490753c89037ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Past Incidents” section to the status page.
  * Incident entries now show severity, current state, and a chronological update history.
  * Incidents are grouped into active and recently resolved sections, with a clearer empty state when none are available.

* **Bug Fixes**
  * Improved incident ordering and time labels so recent activity appears in the right sequence and reads more naturally.

* **Tests**
  * Added coverage for incident timeline sorting, state handling, activity status, and relative time formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->