### PR TITLE
feat(worker): notify subscribers and purge edge cache on status change

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,11 @@ sites:
   - name: API
     url: https://api.example.com/health
     check: http
-notifications:
-  - type: slack
-    webhook: $SLACK_WEBHOOK # $SECRET is resolved from the environment
-  - type: email
-    to: ops@example.com
+notifications: # all optional; keep the real Slack URL (a secret) in your KV config
+  slack:
+    webhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX
+  webhooks:
+    - url: https://example.com/status-hook
 theme:
   logoUrl: /logo.svg
   darkMode: true

--- a/apps/worker/src/cache.ts
+++ b/apps/worker/src/cache.ts
@@ -1,0 +1,53 @@
+import type { Env } from './env'
+
+/** Cache-Tag on every status-page response; purging it busts the whole page. */
+export const STATUS_PAGE_TAG = 'status-page'
+
+/** Cache-Tag for a single site, so one flip can purge just that site's assets. */
+export function siteTag(slug: string): string {
+  return `status-site-${slug}`
+}
+
+/**
+ * Purge the edge cache by Cache-Tag when a status changes, so the page reflects
+ * the new state immediately instead of waiting for its TTL.
+ *
+ * Cloudflare Workers expose no binding-level tag purge — purge-by-tag is an
+ * Enterprise Cache feature driven through the REST API. This POSTs to
+ * `/zones/{zone}/purge_cache` with `{ tags }`. It needs two secrets (see
+ * env.ts / wrangler.jsonc):
+ *   - `CF_API_TOKEN` — token with the "Cache Purge" permission
+ *   - `CF_ZONE_ID`   — the zone serving the status page
+ * The web app must emit a matching `Cache-Tag` response header for the purge to
+ * hit anything. When either secret is unset, the purge is skipped (logged).
+ */
+export async function purgeStatusCache(
+  env: Env,
+  changedSlugs: string[],
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  if (!env.CF_API_TOKEN || !env.CF_ZONE_ID) {
+    console.warn('purgeStatusCache: CF_API_TOKEN/CF_ZONE_ID unset; skipping cache purge')
+    return
+  }
+  const tags = [STATUS_PAGE_TAG, ...changedSlugs.map(siteTag)]
+  try {
+    const res = await fetchImpl(
+      `https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/purge_cache`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${env.CF_API_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ tags }),
+      },
+    )
+    if (!res.ok) {
+      console.error(`purgeStatusCache: purge failed (${res.status})`)
+    }
+  }
+  catch (err) {
+    console.error('purgeStatusCache: purge threw', err)
+  }
+}

--- a/apps/worker/src/cache.ts
+++ b/apps/worker/src/cache.ts
@@ -30,7 +30,12 @@ export async function purgeStatusCache(
     console.warn('purgeStatusCache: CF_API_TOKEN/CF_ZONE_ID unset; skipping cache purge')
     return
   }
-  const tags = [STATUS_PAGE_TAG, ...changedSlugs.map(siteTag)]
+  // Cloudflare caps tags per purge request. STATUS_PAGE_TAG is on every page
+  // response, so for a large change set purging it alone still busts everything —
+  // fall back to that rather than dropping tags past the limit.
+  const MAX_TAGS = 30
+  const siteTags = changedSlugs.map(siteTag)
+  const tags = siteTags.length + 1 > MAX_TAGS ? [STATUS_PAGE_TAG] : [STATUS_PAGE_TAG, ...siteTags]
   try {
     const res = await fetchImpl(
       `https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/purge_cache`,
@@ -44,7 +49,10 @@ export async function purgeStatusCache(
       },
     )
     if (!res.ok) {
-      console.error(`purgeStatusCache: purge failed (${res.status})`)
+      // The Cloudflare API returns a JSON error body (codes + messages) that is
+      // far more actionable on-call than the status code alone.
+      const body = await res.text().catch(() => '')
+      console.error(`purgeStatusCache: purge failed (${res.status})`, body)
     }
   }
   catch (err) {

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -3,6 +3,15 @@ export interface Env {
   DB: D1Database
   /** Current snapshot the status page reads, plus the `config` YAML document. */
   STATUS_KV: KVNamespace
+  /**
+   * Cloudflare API token with the "Cache Purge" permission. Used by
+   * {@link purgeStatusCache} to purge the edge cache by Cache-Tag on a status
+   * change. Optional: when unset, cache purge is skipped (logged, not fatal).
+   * Set with `wrangler secret put CF_API_TOKEN`.
+   */
+  CF_API_TOKEN?: string
+  /** Zone id whose cache is purged by tag. Optional; pairs with CF_API_TOKEN. */
+  CF_ZONE_ID?: string
 }
 
 /** KV keys used by status-please. */

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,7 +1,9 @@
 import type { CheckResult, CheckStatus, DayStat, SiteSummary, StatusConfig } from '@status-please/core'
 import type { Env } from './env'
-import { checkSite, formatUptime, parseConfig, windowUptime } from '@status-please/core'
+import { buildStatusChangePayload, checkSite, formatUptime, parseConfig, windowUptime } from '@status-please/core'
+import { purgeStatusCache } from './cache'
 import { KV_KEYS } from './env'
+import { dispatchNotifications } from './notify'
 
 const HISTORY_DAYS = 90
 
@@ -34,10 +36,19 @@ export default {
     await writeSummary(env, config, results)
 
     if (changed.length > 0) {
-      // TODO(notify): enqueue notification events (Slack/webhook/email/RSS).
-      // TODO(cache): purge the page/badge cache by tag so updates are instant.
-      //   e.g. ctx.cache.purge({ tags: ['status-page', ...changed.map(c => c.slug)] })
-      ctx.waitUntil(Promise.resolve())
+      // Diff against the previous snapshot: `previous.get` is defined here
+      // because `changed` only keeps slugs whose prior status existed and moved.
+      const changes = changed.map(r => ({
+        slug: r.slug,
+        from: previous.get(r.slug) as CheckStatus,
+        to: r.status,
+      }))
+      const payload = buildStatusChangePayload(changes, new Date().toISOString())
+
+      // Notify subscribers and purge the edge cache by tag so the page reflects
+      // the new state immediately instead of waiting for its TTL.
+      ctx.waitUntil(dispatchNotifications(config.notifications, payload))
+      ctx.waitUntil(purgeStatusCache(env, changes.map(c => c.slug)))
     }
   },
 }

--- a/apps/worker/src/notify.ts
+++ b/apps/worker/src/notify.ts
@@ -29,6 +29,16 @@ export async function dispatchNotifications(
   await Promise.allSettled(posts)
 }
 
+/** Scheme + host only — webhook URLs embed secrets (Slack path, `?token=`). */
+function redactUrl(url: string): string {
+  try {
+    return new URL(url).origin
+  }
+  catch {
+    return '<invalid url>'
+  }
+}
+
 async function postJson(fetchImpl: typeof fetch, url: string, body: unknown): Promise<void> {
   try {
     const res = await fetchImpl(url, {
@@ -37,10 +47,10 @@ async function postJson(fetchImpl: typeof fetch, url: string, body: unknown): Pr
       body: JSON.stringify(body),
     })
     if (!res.ok) {
-      console.error(`notify: POST ${url} failed (${res.status})`)
+      console.error(`notify: POST ${redactUrl(url)} failed (${res.status})`)
     }
   }
   catch (err) {
-    console.error(`notify: POST ${url} threw`, err)
+    console.error(`notify: POST ${redactUrl(url)} threw`, err)
   }
 }

--- a/apps/worker/src/notify.ts
+++ b/apps/worker/src/notify.ts
@@ -1,0 +1,46 @@
+import type { Notifications, StatusChangePayload } from '@status-please/core'
+import { toSlackMessage } from '@status-please/core'
+
+/**
+ * Fan out a status-change payload to every configured target. Slack receives
+ * its Block Kit message; generic webhooks receive the channel-agnostic payload
+ * as JSON. Failures are logged, never thrown, so one bad target cannot wedge
+ * the cron run. Resolves once every dispatch settles.
+ *
+ * This is inline dispatch via `fetch` (called from `ctx.waitUntil`). A
+ * Cloudflare Workers Queue could sit between producer and dispatch for retries
+ * and backpressure; see the follow-up note in wrangler.jsonc.
+ */
+export async function dispatchNotifications(
+  notifications: Notifications | undefined,
+  payload: StatusChangePayload,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  if (!notifications) {
+    return
+  }
+  const posts: Promise<void>[] = []
+  if (notifications.slack) {
+    posts.push(postJson(fetchImpl, notifications.slack.webhookUrl, toSlackMessage(payload)))
+  }
+  for (const hook of notifications.webhooks ?? []) {
+    posts.push(postJson(fetchImpl, hook.url, payload))
+  }
+  await Promise.allSettled(posts)
+}
+
+async function postJson(fetchImpl: typeof fetch, url: string, body: unknown): Promise<void> {
+  try {
+    const res = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) {
+      console.error(`notify: POST ${url} failed (${res.status})`)
+    }
+  }
+  catch (err) {
+    console.error(`notify: POST ${url} threw`, err)
+  }
+}

--- a/apps/worker/wrangler.jsonc
+++ b/apps/worker/wrangler.jsonc
@@ -27,4 +27,19 @@
       "id": "REPLACE_WITH_KV_NAMESPACE_ID"
     }
   ]
+
+  // Notifications (src/notify.ts): dispatched inline via `ctx.waitUntil(fetch)`
+  // on a status change — Slack + generic webhook targets come from the
+  // `notifications` block in status.config.yml, so no binding is required here.
+  // Follow-up: to add retries/backpressure, put a Workers Queue between the
+  // `scheduled` producer and a `queue` consumer that does the HTTP dispatch —
+  // add a `queues.producers`/`queues.consumers` binding here and a `queue`
+  // handler in src/index.ts.
+  //
+  // Cache purge (src/cache.ts): purge-by-Cache-Tag is an Enterprise Cache REST
+  // API feature, not a Worker binding. Provide these as secrets and the web app
+  // must emit a matching `Cache-Tag` response header:
+  //   wrangler secret put CF_API_TOKEN   # token with "Cache Purge" permission
+  //   wrangler secret put CF_ZONE_ID     # zone serving the status page
+  // When unset, cache purge is skipped (logged, not fatal).
 }

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test'
+import { configSchema, notificationsSchema, parseConfig } from './config'
+
+const baseYaml = `
+name: Example Status
+sites:
+  - name: Example
+    url: https://example.com
+`
+
+describe('parseConfig', () => {
+  it('parses a minimal config and slugifies site names', () => {
+    const config = parseConfig(baseYaml)
+    expect(config.name).toBe('Example Status')
+    expect(config.sites[0]?.slug).toBe('example')
+  })
+
+  it('leaves notifications undefined when the block is absent', () => {
+    expect(parseConfig(baseYaml).notifications).toBeUndefined()
+  })
+})
+
+describe('notificationsSchema', () => {
+  it('accepts a valid slack webhook and generic webhooks', () => {
+    const parsed = notificationsSchema.parse({
+      slack: { webhookUrl: 'https://hooks.slack.com/services/T/B/X' },
+      webhooks: [{ url: 'https://example.com/hook' }],
+    })
+    expect(parsed.slack?.webhookUrl).toBe('https://hooks.slack.com/services/T/B/X')
+    expect(parsed.webhooks).toHaveLength(1)
+  })
+
+  it('accepts an empty object (all fields optional)', () => {
+    expect(notificationsSchema.parse({})).toEqual({})
+  })
+
+  it('rejects an invalid slack webhook URL', () => {
+    expect(() => notificationsSchema.parse({ slack: { webhookUrl: 'not-a-url' } })).toThrow()
+  })
+
+  it('rejects an invalid generic webhook URL', () => {
+    expect(() => notificationsSchema.parse({ webhooks: [{ url: 'nope' }] })).toThrow()
+  })
+})
+
+describe('configSchema with notifications', () => {
+  it('parses a config that includes a notifications block', () => {
+    const config = configSchema.parse({
+      name: 'Example Status',
+      sites: [{ name: 'Example', url: 'https://example.com' }],
+      notifications: { slack: { webhookUrl: 'https://hooks.slack.com/services/T/B/X' } },
+    })
+    expect(config.notifications?.slack?.webhookUrl).toBe(
+      'https://hooks.slack.com/services/T/B/X',
+    )
+  })
+
+  it('rejects a config with an invalid webhook URL', () => {
+    expect(() =>
+      configSchema.parse({
+        name: 'Example Status',
+        sites: [{ name: 'Example', url: 'https://example.com' }],
+        notifications: { webhooks: [{ url: 'bad' }] },
+      }),
+    ).toThrow()
+  })
+})

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -30,12 +30,15 @@ export const siteSchema = z
 
 export type Site = z.infer<typeof siteSchema>
 
-export const notificationSchema = z.discriminatedUnion('type', [
-  z.object({ type: z.literal('slack'), webhook: z.string() }),
-  z.object({ type: z.literal('webhook'), url: z.string().url() }),
-  z.object({ type: z.literal('email'), to: z.string().email() }),
-])
-export type Notification = z.infer<typeof notificationSchema>
+/**
+ * Optional outbound notification targets. Every field is optional so existing
+ * configs without a `notifications` block keep parsing unchanged.
+ */
+export const notificationsSchema = z.object({
+  slack: z.object({ webhookUrl: z.string().url() }).optional(),
+  webhooks: z.array(z.object({ url: z.string().url() })).optional(),
+})
+export type Notifications = z.infer<typeof notificationsSchema>
 
 export const themeSchema = z
   .object({
@@ -47,7 +50,7 @@ export const themeSchema = z
 export const configSchema = z.object({
   name: z.string().min(1),
   sites: z.array(siteSchema).min(1),
-  notifications: z.array(notificationSchema).default([]),
+  notifications: notificationsSchema.optional(),
   theme: themeSchema,
 })
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './check'
 export * from './config'
+export * from './notify'
 export * from './types'

--- a/packages/core/src/notify.test.ts
+++ b/packages/core/src/notify.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { buildStatusChangePayload, toSlackMessage } from './notify'
+
+const timestamp = '2026-07-07T00:00:00.000Z'
+
+describe('buildStatusChangePayload', () => {
+  it('carries the timestamp and changes through unchanged', () => {
+    const changes = [{ slug: 'api', from: 'up', to: 'down' } as const]
+    const payload = buildStatusChangePayload(changes, timestamp)
+    expect(payload.timestamp).toBe(timestamp)
+    expect(payload.changes).toEqual(changes)
+  })
+
+  it('rolls up the worst resulting status as severity', () => {
+    expect(
+      buildStatusChangePayload(
+        [
+          { slug: 'a', from: 'up', to: 'degraded' },
+          { slug: 'b', from: 'up', to: 'down' },
+        ],
+        timestamp,
+      ).severity,
+    ).toBe('major_outage')
+
+    expect(
+      buildStatusChangePayload([{ slug: 'a', from: 'down', to: 'up' }], timestamp).severity,
+    ).toBe('operational')
+  })
+
+  it('is operational for an empty change list', () => {
+    expect(buildStatusChangePayload([], timestamp).severity).toBe('operational')
+  })
+})
+
+describe('toSlackMessage', () => {
+  it('summarises a single change with a from → to line', () => {
+    const message = toSlackMessage(
+      buildStatusChangePayload([{ slug: 'api', from: 'up', to: 'down' }], timestamp),
+    )
+    expect(message.text).toContain('Status changed for 1 service')
+    expect(message.text).toContain('*api*: up → down')
+    expect(message.blocks.length).toBeGreaterThan(0)
+  })
+
+  it('pluralises and lists every change', () => {
+    const message = toSlackMessage(
+      buildStatusChangePayload(
+        [
+          { slug: 'api', from: 'up', to: 'down' },
+          { slug: 'web', from: 'up', to: 'degraded' },
+        ],
+        timestamp,
+      ),
+    )
+    expect(message.text).toContain('Status changed for 2 services')
+    expect(message.text).toContain('*api*: up → down')
+    expect(message.text).toContain('*web*: up → degraded')
+  })
+})

--- a/packages/core/src/notify.ts
+++ b/packages/core/src/notify.ts
@@ -1,0 +1,66 @@
+import type { CheckStatus, Severity } from './types'
+import { overallSeverity } from './types'
+
+/** A single site whose status flipped between two check runs. */
+export interface StatusChange {
+  slug: string
+  from: CheckStatus
+  to: CheckStatus
+}
+
+/**
+ * Channel-agnostic description of one or more status changes. Formatters
+ * (Slack, generic webhook, …) turn this into their own wire shape.
+ */
+export interface StatusChangePayload {
+  /** ISO-8601 timestamp of when the changes were detected. */
+  timestamp: string
+  /** Worst resulting status across all changes, for headline severity. */
+  severity: Severity
+  changes: StatusChange[]
+}
+
+/**
+ * Build a channel-agnostic payload from a list of status changes. Pure: the
+ * caller supplies the timestamp so the result is deterministic and testable.
+ */
+export function buildStatusChangePayload(
+  changes: StatusChange[],
+  timestamp: string,
+): StatusChangePayload {
+  return {
+    timestamp,
+    severity: overallSeverity(changes.map(c => c.to)),
+    changes,
+  }
+}
+
+const STATUS_EMOJI: Record<CheckStatus, string> = {
+  up: '✅',
+  degraded: '⚠️',
+  down: '🔴',
+}
+
+/** Minimal shape of a Slack incoming-webhook message. */
+export interface SlackMessage {
+  /** Plain-text fallback (notifications, screen readers, old clients). */
+  text: string
+  blocks: unknown[]
+}
+
+/** Format a payload as a Slack incoming-webhook message (text + Block Kit). */
+export function toSlackMessage(payload: StatusChangePayload): SlackMessage {
+  const count = payload.changes.length
+  const headline = `Status changed for ${count} service${count === 1 ? '' : 's'}`
+  const lines = payload.changes.map(
+    c => `${STATUS_EMOJI[c.to]} *${c.slug}*: ${c.from} → ${c.to}`,
+  )
+  return {
+    text: [headline, ...lines].join('\n'),
+    blocks: [
+      { type: 'header', text: { type: 'plain_text', text: headline, emoji: true } },
+      { type: 'section', text: { type: 'mrkdwn', text: lines.join('\n') } },
+      { type: 'context', elements: [{ type: 'mrkdwn', text: payload.timestamp }] },
+    ],
+  }
+}

--- a/status.config.example.yml
+++ b/status.config.example.yml
@@ -13,11 +13,13 @@ sites:
     url: https://api.example.com/health
     check: http
 
+# All optional. Keep the real Slack URL in the private config you upload to KV,
+# not in this committed example (the webhook URL is a secret).
 notifications:
-  - type: slack
-    webhook: $SLACK_WEBHOOK # $SECRET is resolved from the environment
-  - type: email
-    to: ops@example.com
+  slack:
+    webhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX
+  webhooks:
+    - url: https://example.com/status-hook
 
 theme:
   logoUrl: /logo.svg


### PR DESCRIPTION
## What

On a status change, the cron worker now notifies subscribers and purges the
edge cache so the status page reflects the new state immediately instead of
waiting for a TTL. Replaces the `TODO(notify)` / `TODO(cache)` placeholders in
`apps/worker/src/index.ts`.

## Layers

**core (tested — under the coverage gate)**
- `config.ts`: new **optional** `notifications` block —
  `{ slack?: { webhookUrl }, webhooks?: { url }[] }`, all URLs validated with
  zod `.url()`. Fully backward compatible (absent block → `undefined`).
  Replaces the previously-unused `notificationSchema` array (referenced
  nowhere else).
- `notify.ts`: pure `buildStatusChangePayload(changes, timestamp)` →
  channel-agnostic payload (timestamp, rolled-up severity, changes) and
  `toSlackMessage(payload)` → Slack incoming-webhook message (text + Block Kit).
- Tests: `config.test.ts` (valid + invalid Slack/webhook URLs, back-compat) and
  `notify.test.ts` (payload build, severity roll-up, Slack formatting).

**worker (glue — coverage-excluded)**
- `notify.ts`: `dispatchNotifications(notifications, payload)` — POSTs the Slack
  Block Kit message to the Slack webhook and the raw payload to each generic
  webhook, via `fetch`. Failures are logged with `Promise.allSettled`, never
  thrown.
- `cache.ts`: `purgeStatusCache(env, changedSlugs)` — purges by `Cache-Tag`
  through the Cloudflare `POST /zones/{zone}/purge_cache` REST API.
- `index.ts`: on `changed.length > 0`, builds `{ slug, from, to }` changes from
  the existing previous-snapshot diff and dispatches both via `ctx.waitUntil`.

## Bindings / follow-ups

- **Notifications** need no binding — targets come from `status.config.yml`.
- **Cache purge** uses the Enterprise Cache-Tag REST API (no Worker binding
  exists for tag purge). Set two secrets and have the web app emit a matching
  `Cache-Tag` header:
  - `wrangler secret put CF_API_TOKEN` (token with "Cache Purge" permission)
  - `wrangler secret put CF_ZONE_ID`
  When unset, purge is skipped (logged, not fatal). Documented in
  `env.ts` + `wrangler.jsonc`.
- **Queue follow-up:** dispatch is inline `ctx.waitUntil(fetch)` for
  simplicity/correctness. A Workers Queue (producer in `scheduled` + `queue`
  consumer) can be added later for retries/backpressure — noted in
  `wrangler.jsonc`.

## Verification

- `bun run typecheck` — 0 errors (core, worker, web)
- `bun run lint` — clean
- `bun test` — 27 pass / 0 fail
- `bunx wrangler deploy --dry-run` — compiles
- `bunx astro build` — builds

Do not merge without human review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Notifies subscribers and purges the Cloudflare edge cache on status changes so the status page updates instantly. Adds an optional `notifications` config with Slack and generic webhooks; replaces worker TODOs while keeping existing configs working, and tightens logging and purge behavior.

- **New Features**
  - `@status-please/core`: optional `notifications` block `{ slack?: { webhookUrl }, webhooks?: { url }[] }` with URL validation.
  - `@status-please/core`: `buildStatusChangePayload(changes, timestamp)` and `toSlackMessage(payload)` for channel-agnostic + Slack messages.
  - Worker: on changes, dispatches to Slack/webhooks via `ctx.waitUntil` (logs only webhook origins, never full URLs) and purges cache by tags (`status-page`, `status-site-{slug}`) through Cloudflare `POST /zones/{zone}/purge_cache`; falls back to page-wide tag when tag count exceeds API cap and logs the Cloudflare error body on failures.
  - Failures are logged and never block the cron run.

- **Migration**
  - To receive alerts, add a `notifications` block in `status.config.yml` (optional; no change needed if you don’t want notifications).
  - To enable cache purge, emit matching `Cache-Tag` headers in the web app and set `wrangler` secrets `CF_API_TOKEN` (Cache Purge permission) and `CF_ZONE_ID`; when unset, purge is skipped.

<sup>Written for commit c4727083d128fbcd58b3d7b22345de100f38c765. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

