### PR TITLE
feat: close the cache-purge loop with shared Cache-Tag emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,23 @@ bun install
 bun run deploy
 ```
 
+### Instant cache invalidation (optional)
+
+By default the page is edge-cached for `s-maxage=60`, so a status change shows up
+within a minute. For **near-instant** updates, the check Worker purges the edge
+cache by [Cache-Tag](https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/)
+the moment a status flips. The page already emits a matching `Cache-Tag` response
+header (`status-page` + one `status-site-<slug>` per component); you just provide
+the Worker two secrets (purge-by-tag is an Enterprise Cache feature):
+
+```bash
+bunx wrangler secret put CF_API_TOKEN   # API token with the "Cache Purge" permission
+bunx wrangler secret put CF_ZONE_ID     # the zone serving your status page
+```
+
+When these are unset the purge is skipped (logged, not fatal) and the page simply
+refreshes on its 60s TTL.
+
 Detailed setup will land with the first release — see the [Roadmap](#roadmap).
 
 ---

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ within a minute. For **near-instant** updates, the check Worker purges the edge
 cache by [Cache-Tag](https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/)
 the moment a status flips. The page already emits a matching `Cache-Tag` response
 header (`status-page` + one `status-site-<slug>` per component); you just provide
-the Worker two secrets (purge-by-tag is an Enterprise Cache feature):
+the Worker two secrets (purge-by-tag is [available on all Cloudflare plans](https://developers.cloudflare.com/changelog/post/2025-04-01-purge-for-all/) since April 2025):
 
 ```bash
 bunx wrangler secret put CF_API_TOKEN   # API token with the "Cache Purge" permission

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import { overallSeverity } from '@status-please/core'
+import { cacheTagHeader, overallSeverity } from '@status-please/core'
 import { IncidentList } from '../components/IncidentList'
 import { StatusBanner } from '../components/StatusBanner'
 import { StatusList } from '../components/StatusList'
@@ -13,6 +13,9 @@ const incidents = await getIncidents()
 // Render at the edge, cache the result, and let Workers Cache serve subsequent
 // hits. The check Worker purges by tag on a status change (see wrangler.jsonc).
 Astro.response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=600')
+// Tag the cached response so the Worker's purge-by-tag (status-page + each
+// site) invalidates it the instant a status changes, not on TTL expiry.
+Astro.response.headers.set('Cache-Tag', cacheTagHeader(summary.map(s => s.slug)))
 ---
 
 <html lang="en" class="min-h-full">

--- a/apps/worker/src/cache.ts
+++ b/apps/worker/src/cache.ts
@@ -1,12 +1,7 @@
 import type { Env } from './env'
-
-/** Cache-Tag on every status-page response; purging it busts the whole page. */
-export const STATUS_PAGE_TAG = 'status-page'
-
-/** Cache-Tag for a single site, so one flip can purge just that site's assets. */
-export function siteTag(slug: string): string {
-  return `status-site-${slug}`
-}
+// Tag helpers live in core so the purge side (here) and the emit side
+// (apps/web's Cache-Tag header) share one definition and can't drift.
+import { cacheTags, STATUS_PAGE_TAG } from '@status-please/core'
 
 /**
  * Purge the edge cache by Cache-Tag when a status changes, so the page reflects
@@ -34,8 +29,8 @@ export async function purgeStatusCache(
   // response, so for a large change set purging it alone still busts everything —
   // fall back to that rather than dropping tags past the limit.
   const MAX_TAGS = 30
-  const siteTags = changedSlugs.map(siteTag)
-  const tags = siteTags.length + 1 > MAX_TAGS ? [STATUS_PAGE_TAG] : [STATUS_PAGE_TAG, ...siteTags]
+  const all = cacheTags(changedSlugs)
+  const tags = all.length > MAX_TAGS ? [STATUS_PAGE_TAG] : all
   try {
     const res = await fetchImpl(
       `https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/purge_cache`,

--- a/apps/worker/src/cache.ts
+++ b/apps/worker/src/cache.ts
@@ -7,8 +7,8 @@ import { cacheTags, STATUS_PAGE_TAG } from '@status-please/core'
  * Purge the edge cache by Cache-Tag when a status changes, so the page reflects
  * the new state immediately instead of waiting for its TTL.
  *
- * Cloudflare Workers expose no binding-level tag purge — purge-by-tag is an
- * Enterprise Cache feature driven through the REST API. This POSTs to
+ * Cloudflare Workers expose no binding-level tag purge — purge-by-tag is driven
+ * through the REST API (available on all Cloudflare plans since April 2025). This POSTs to
  * `/zones/{zone}/purge_cache` with `{ tags }`. It needs two secrets (see
  * env.ts / wrangler.jsonc):
  *   - `CF_API_TOKEN` — token with the "Cache Purge" permission

--- a/apps/worker/wrangler.jsonc
+++ b/apps/worker/wrangler.jsonc
@@ -36,8 +36,9 @@
   // add a `queues.producers`/`queues.consumers` binding here and a `queue`
   // handler in src/index.ts.
   //
-  // Cache purge (src/cache.ts): purge-by-Cache-Tag is an Enterprise Cache REST
-  // API feature, not a Worker binding. Provide these as secrets and the web app
+  // Cache purge (src/cache.ts): purge-by-Cache-Tag is a REST API feature (on all
+  // Cloudflare plans since Apr 2025), not a Worker binding. Provide these as
+  // secrets and the web app
   // must emit a matching `Cache-Tag` response header:
   //   wrangler secret put CF_API_TOKEN   # token with "Cache Purge" permission
   //   wrangler secret put CF_ZONE_ID     # zone serving the status page

--- a/packages/core/src/cache.test.ts
+++ b/packages/core/src/cache.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'bun:test'
+import { cacheTagHeader, cacheTags, siteTag, STATUS_PAGE_TAG } from './cache'
+
+describe('siteTag', () => {
+  it('namespaces a slug', () => {
+    expect(siteTag('api')).toBe('status-site-api')
+  })
+})
+
+describe('cacheTags', () => {
+  it('is the page tag plus one tag per site', () => {
+    expect(cacheTags(['website', 'api'])).toEqual([
+      STATUS_PAGE_TAG,
+      'status-site-website',
+      'status-site-api',
+    ])
+  })
+
+  it('is just the page tag when there are no sites', () => {
+    expect(cacheTags([])).toEqual([STATUS_PAGE_TAG])
+  })
+})
+
+describe('cacheTagHeader', () => {
+  it('comma-joins the tags for the Cache-Tag header', () => {
+    expect(cacheTagHeader(['api'])).toBe('status-page,status-site-api')
+  })
+})

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -1,0 +1,24 @@
+/**
+ * Cache-Tag values shared by the two sides of the purge loop: the status page
+ * (apps/web) emits them as a `Cache-Tag` response header, and the check Worker
+ * (apps/worker) purges them by tag on a status change. Keeping them here means
+ * the emit side and the purge side can never drift apart.
+ */
+
+/** Tag on every status-page response; purging it busts the whole page. */
+export const STATUS_PAGE_TAG = 'status-page'
+
+/** Tag for a single site, so one flip can purge just that site's assets. */
+export function siteTag(slug: string): string {
+  return `status-site-${slug}`
+}
+
+/** The full tag set for a page showing `slugs`: the page tag plus one per site. */
+export function cacheTags(slugs: string[]): string[] {
+  return [STATUS_PAGE_TAG, ...slugs.map(siteTag)]
+}
+
+/** Comma-joined `Cache-Tag` response header value for a page showing `slugs`. */
+export function cacheTagHeader(slugs: string[]): string {
+  return cacheTags(slugs).join(',')
+}

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -8,7 +8,12 @@
 /** Tag on every status-page response; purging it busts the whole page. */
 export const STATUS_PAGE_TAG = 'status-page'
 
-/** Tag for a single site, so one flip can purge just that site's assets. */
+/**
+ * Tag for a single site, so one flip can purge just that site's assets.
+ * `slug` must be Cache-Tag-safe (no commas/whitespace — those would split or
+ * corrupt the header). The config schema enforces this at parse time
+ * (`siteSchema.slug`), so callers here don't re-validate.
+ */
 export function siteTag(slug: string): string {
   return `status-site-${slug}`
 }

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -18,6 +18,16 @@ describe('parseConfig', () => {
   it('leaves notifications undefined when the block is absent', () => {
     expect(parseConfig(baseYaml).notifications).toBeUndefined()
   })
+
+  it('accepts a valid explicit slug', () => {
+    const config = parseConfig(`${baseYaml}    slug: my-api\n`)
+    expect(config.sites[0]?.slug).toBe('my-api')
+  })
+
+  it('rejects an explicit slug with Cache-Tag-unsafe characters', () => {
+    // A comma would split the Cache-Tag header into bogus tags.
+    expect(() => parseConfig(`${baseYaml}    slug: my,service\n`)).toThrow()
+  })
 })
 
 describe('notificationsSchema', () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -23,8 +23,12 @@ export const siteSchema = z
     expectedStatusCodes: z.array(z.number().int()).default([200]),
     /** Response time above this (ms) marks the site `degraded` rather than `up`. */
     maxResponseTime: z.number().int().positive().default(5000),
-    /** Optional explicit slug; defaults to slugify(name). */
-    slug: z.string().optional(),
+    /**
+     * Optional explicit slug; defaults to slugify(name). Constrained to the
+     * same charset slugify emits so it's safe to embed in a `Cache-Tag` (no
+     * commas/whitespace, which would corrupt the header — see cache.ts).
+     */
+    slug: z.string().regex(/^[a-z0-9-]+$/, 'slug must be lowercase letters, digits, and hyphens').optional(),
   })
   .transform(site => ({ ...site, slug: site.slug ?? slugify(site.name) }))
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './cache'
 export * from './check'
 export * from './config'
 export * from './incidents'


### PR DESCRIPTION
Completes the deployment follow-up from #8: the check Worker purges the edge cache **by Cache-Tag** on a status change, but that only invalidates anything if the page's responses actually carry those tags. Now they do.

## What
- **core** (`packages/core/src/cache.ts`, new): the cache-tag helpers — `STATUS_PAGE_TAG`, `siteTag(slug)`, `cacheTags(slugs)`, `cacheTagHeader(slugs)` — now live in one place so the **purge side** (worker) and the **emit side** (web) share a single definition and can't drift. Unit-tested.
- **worker** (`cache.ts`): imports the tags from core instead of defining them locally (behavior unchanged, incl. the >30-tag broad-purge fallback).
- **web** (`index.astro`): emits a `Cache-Tag` response header — `status-page` plus one `status-site-<slug>` per component — so a purge invalidates the cached page **instantly** instead of on the 60s TTL.
- **README**: documents the `CF_API_TOKEN` / `CF_ZONE_ID` purge secrets (Enterprise Cache; optional — when unset, purge is skipped and the page refreshes on TTL).

## Verification
Drove the dev server and confirmed the response header:
```
Cache-Tag: status-page,status-site-website,status-site-api,status-site-cdn
```
— exactly the tags the Worker purges. `typecheck` (0 errors), `lint`, **48 tests**, web `build`, and worker `deploy --dry-run` all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables instant cache invalidation for the status page by emitting `Cache-Tag` headers and sharing tag helpers across web and worker. Adds slug validation so tags are always safe; status changes appear immediately instead of after the 60s TTL.

- **New Features**
  - Shared cache-tag helpers in `@status-please/core` (`STATUS_PAGE_TAG`, `siteTag`, `cacheTags`, `cacheTagHeader`) with tests.
  - Web emits a `Cache-Tag` header (`status-page` + one `status-site-<slug>` per component).
  - Worker imports tags from `@status-please/core` and purges by tag (behavior unchanged).
  - Config validates explicit site `slug` as `/^[a-z0-9-]+$/` to keep `Cache-Tag` safe; tests added.

- **Migration**
  - To enable purge-by-tag, set `CF_API_TOKEN` and `CF_ZONE_ID` (available on all Cloudflare plans since Apr 2025). Without these, the page updates on the 60s TTL.

<sup>Written for commit bb85786efbf7ca6a2c11d220d2fda1415a508912. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

