### PR TITLE
ci: add manual Cloudflare deploy workflow + deployment runbook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,18 +18,21 @@ jobs:
   deploy:
     name: Deploy worker + web to Cloudflare
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # bound the worst case — concurrency lock (cancel-in-progress:false) must not hang forever
     environment: production # add protection rules (approvals) in repo settings
     permissions:
       contents: read
     env:
-      # Secrets: set with `gh secret set`. Wrangler reads these from the env.
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      # Variables (not secret — resource IDs): set with `gh variable set`.
+      # Resource IDs are not secret — set with `gh variable set`. The Cloudflare
+      # secrets are NOT job-level: they're scoped per-step (below) to only the
+      # steps that call Wrangler, so checkout/install/build never see them.
       CF_D1_DATABASE_ID: ${{ vars.CF_D1_DATABASE_ID }}
       CF_KV_NAMESPACE_ID: ${{ vars.CF_KV_NAMESPACE_ID }}
     steps:
       - name: Preflight — required secrets/variables present
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           missing=""
           [ -n "$CLOUDFLARE_API_TOKEN" ] || missing="$missing CLOUDFLARE_API_TOKEN(secret)"
@@ -50,36 +53,49 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # --ignore-scripts: don't run dependency lifecycle scripts on a deploy.
+        # Verified the build + wrangler bundling still work (Astro uses rolldown,
+        # esbuild/workerd resolve their platform binaries via optionalDependencies).
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Inject account-specific resource IDs
         # Idempotent: only rewrites the committed placeholders. A fork that
         # commits real IDs is left untouched.
+        # `|` delimiter (not `/`) so a future ID shape containing `/` or `&`
+        # can't corrupt the substitution. Cloudflare IDs are hex+hyphen today.
         run: |
           for f in apps/worker/wrangler.jsonc apps/web/wrangler.jsonc; do
-            sed -i "s/REPLACE_WITH_D1_DATABASE_ID/$CF_D1_DATABASE_ID/g; s/REPLACE_WITH_KV_NAMESPACE_ID/$CF_KV_NAMESPACE_ID/g" "$f"
+            sed -i "s|REPLACE_WITH_D1_DATABASE_ID|$CF_D1_DATABASE_ID|g; s|REPLACE_WITH_KV_NAMESPACE_ID|$CF_KV_NAMESPACE_ID|g" "$f"
           done
 
-      - name: Build
+      - name: Build (fail fast before touching production)
         run: bun run build
 
       - name: Apply D1 schema (idempotent — CREATE TABLE IF NOT EXISTS)
-        working-directory: apps/worker
-        run: bunx wrangler d1 execute status-please --remote --file=./schema.sql --yes
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bun run --filter '@status-please/worker' db:apply:remote
 
       - name: Upload config to KV
-        working-directory: apps/worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          if [ ! -f ../../status.config.yml ]; then
+          if [ ! -f status.config.yml ]; then
             echo "::error::status.config.yml not found. Create it from status.config.example.yml (see DEPLOYMENT.md)."
             exit 1
           fi
-          bunx wrangler kv key put config --binding=STATUS_KV --path=../../status.config.yml --remote
+          bun run --filter '@status-please/worker' kv:config
 
       - name: Deploy check Worker
-        working-directory: apps/worker
-        run: bunx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bun run --filter '@status-please/worker' deploy
 
       - name: Deploy status page
-        working-directory: apps/web
-        run: bunx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bun run --filter '@status-please/web' deploy:publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,85 @@
+name: Deploy
+
+# Manual only: production infrastructure (D1/KV) and Cloudflare credentials must
+# exist before this can do anything, so a maintainer runs it deliberately.
+on:
+  workflow_dispatch:
+
+# Least privilege — Wrangler authenticates with the API token, not the GITHUB_TOKEN.
+permissions:
+  contents: read
+
+# Never let two deploys race; cancel is off so an in-flight deploy finishes.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy worker + web to Cloudflare
+    runs-on: ubuntu-latest
+    environment: production # add protection rules (approvals) in repo settings
+    permissions:
+      contents: read
+    env:
+      # Secrets: set with `gh secret set`. Wrangler reads these from the env.
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Variables (not secret — resource IDs): set with `gh variable set`.
+      CF_D1_DATABASE_ID: ${{ vars.CF_D1_DATABASE_ID }}
+      CF_KV_NAMESPACE_ID: ${{ vars.CF_KV_NAMESPACE_ID }}
+    steps:
+      - name: Preflight — required secrets/variables present
+        run: |
+          missing=""
+          [ -n "$CLOUDFLARE_API_TOKEN" ] || missing="$missing CLOUDFLARE_API_TOKEN(secret)"
+          [ -n "$CLOUDFLARE_ACCOUNT_ID" ] || missing="$missing CLOUDFLARE_ACCOUNT_ID(secret)"
+          [ -n "$CF_D1_DATABASE_ID" ] || missing="$missing CF_D1_DATABASE_ID(variable)"
+          [ -n "$CF_KV_NAMESPACE_ID" ] || missing="$missing CF_KV_NAMESPACE_ID(variable)"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required config:$missing — see DEPLOYMENT.md"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false # deploy auths via CLOUDFLARE_API_TOKEN, not git
+
+      - name: Set up mise (node + bun)
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Inject account-specific resource IDs
+        # Idempotent: only rewrites the committed placeholders. A fork that
+        # commits real IDs is left untouched.
+        run: |
+          for f in apps/worker/wrangler.jsonc apps/web/wrangler.jsonc; do
+            sed -i "s/REPLACE_WITH_D1_DATABASE_ID/$CF_D1_DATABASE_ID/g; s/REPLACE_WITH_KV_NAMESPACE_ID/$CF_KV_NAMESPACE_ID/g" "$f"
+          done
+
+      - name: Build
+        run: bun run build
+
+      - name: Apply D1 schema (idempotent — CREATE TABLE IF NOT EXISTS)
+        working-directory: apps/worker
+        run: bunx wrangler d1 execute status-please --remote --file=./schema.sql --yes
+
+      - name: Upload config to KV
+        working-directory: apps/worker
+        run: |
+          if [ ! -f ../../status.config.yml ]; then
+            echo "::error::status.config.yml not found. Create it from status.config.example.yml (see DEPLOYMENT.md)."
+            exit 1
+          fi
+          bunx wrangler kv key put config --binding=STATUS_KV --path=../../status.config.yml --remote
+
+      - name: Deploy check Worker
+        working-directory: apps/worker
+        run: bunx wrangler deploy
+
+      - name: Deploy status page
+        working-directory: apps/web
+        run: bunx wrangler deploy

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,120 @@
+# Deployment
+
+`status-please` runs entirely on Cloudflare: a **check Worker** (`apps/worker`) probes
+your services on a cron and writes results to **D1** (history) and **KV** (the current
+snapshot + config); a **status page** (`apps/web`, Astro SSR on Workers) renders that
+snapshot at the edge, fronted by Workers Cache.
+
+This guide takes you from an empty Cloudflare account to a live status page, then wires
+the manual GitHub Actions deploy for repeat deploys.
+
+## Prerequisites
+
+- A Cloudflare account (any plan — [cache purge-by-tag is available on all plans](https://developers.cloudflare.com/changelog/post/2025-04-01-purge-for-all/) since April 2025).
+- [mise](https://mise.jdx.dev) + [bun](https://bun.sh): `mise trust && mise install && bun install`.
+- Wrangler auth for local commands: `bunx wrangler login` (or export `CLOUDFLARE_API_TOKEN`).
+
+## 1. Provision D1 + KV
+
+```bash
+bunx wrangler d1 create status-please
+bunx wrangler kv namespace create STATUS_KV
+```
+
+Each command prints an ID. You need two: the **D1 `database_id`** and the **KV namespace `id`**.
+The same D1 and KV are shared by the worker and the web app.
+
+## 2. Wire the resource IDs
+
+Both `apps/worker/wrangler.jsonc` and `apps/web/wrangler.jsonc` ship with placeholders
+(`REPLACE_WITH_D1_DATABASE_ID`, `REPLACE_WITH_KV_NAMESPACE_ID`). For a self-hosted fork,
+just replace them with your real IDs and commit — resource IDs are not secret. (The CI
+deploy in §7 injects them from repo Variables instead, so you can leave the placeholders
+in place if you deploy only through Actions.)
+
+## 3. Write your config
+
+```bash
+cp status.config.example.yml status.config.yml
+$EDITOR status.config.yml   # list your services; see the example for every field
+```
+
+`status.config.yml` is your service list, not a secret — commit it to your fork so the
+deploy can upload it. Keep real webhook URLs out of it (see §6).
+
+## 4. Apply the D1 schema
+
+```bash
+bunx wrangler d1 execute status-please --remote --file=./apps/worker/schema.sql --yes
+```
+
+The schema uses `CREATE TABLE IF NOT EXISTS`, so re-running it is safe.
+
+## 5. Upload the config to KV
+
+```bash
+bunx wrangler kv key put config --binding=STATUS_KV --path=status.config.yml --remote \
+  --config apps/worker/wrangler.jsonc
+```
+
+The worker reads `config` from KV on each run; the page falls back to bundled sample data
+until the first cron populates the `summary` key.
+
+## 6. Set secrets (optional integrations)
+
+Secrets are set on the **check Worker** and never committed.
+
+```bash
+# Outbound notifications — Slack/webhook URLs live in the KV `config`, not here,
+# but keep the config's webhook URLs private (don't commit real ones).
+
+# Instant cache invalidation (see README "Instant cache invalidation"):
+bunx wrangler secret put CF_API_TOKEN --config apps/worker/wrangler.jsonc   # "Cache Purge" permission
+bunx wrangler secret put CF_ZONE_ID   --config apps/worker/wrangler.jsonc   # zone serving the page
+```
+
+When the two cache secrets are unset, a status change still shows up within the 60s edge
+TTL — the purge is skipped, logged, not fatal.
+
+## 7. Deploy
+
+**Locally**, once the IDs are wired (§2):
+
+```bash
+bun run deploy   # builds + deploys the worker, then the web app
+```
+
+**Via GitHub Actions** (`.github/workflows/deploy.yml`, `workflow_dispatch` — manual):
+the workflow injects resource IDs, applies the D1 schema, uploads the config, and deploys
+both. Configure once:
+
+```bash
+# Secrets (sensitive):
+gh secret set CLOUDFLARE_API_TOKEN     # token with Workers/D1/KV edit + Cache Purge
+gh secret set CLOUDFLARE_ACCOUNT_ID
+
+# Variables (resource IDs — not sensitive):
+gh variable set CF_D1_DATABASE_ID
+gh variable set CF_KV_NAMESPACE_ID
+```
+
+Then run it from the **Actions** tab (or `gh workflow run deploy.yml`). The job uses a
+`production` GitHub Environment, so you can add required-reviewer protection in repo
+settings to gate every deploy behind an approval.
+
+## 8. After the first deploy
+
+- The cron runs every 5 minutes (`triggers.crons` in `apps/worker/wrangler.jsonc`); the
+  page shows sample data until the first run writes the real `summary`. Trigger it early
+  with `bunx wrangler dev --test-scheduled` locally, or just wait.
+- Point a custom domain at the `status-please-web` Worker via a route in its
+  `wrangler.jsonc` or the Cloudflare dashboard.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| Page shows sample services | KV `summary` not written yet — wait for the cron, or check the worker's logs (`bunx wrangler tail`). |
+| Deploy workflow fails on preflight | A required secret/variable is unset — the error names which. See §7. |
+| Status changes take ~60s | Cache purge secrets unset (§6) — expected; set `CF_API_TOKEN`/`CF_ZONE_ID` for instant purge. |
+| `d1 execute` prompts in CI | Non-interactive runs auto-confirm; the workflow passes `--yes`. |

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -105,8 +105,9 @@ settings to gate every deploy behind an approval.
 ## 8. After the first deploy
 
 - The cron runs every 5 minutes (`triggers.crons` in `apps/worker/wrangler.jsonc`); the
-  page shows sample data until the first run writes the real `summary`. Trigger it early
-  with `bunx wrangler dev --test-scheduled` locally, or just wait.
+  page shows sample data until the first run writes the real `summary` — just wait for the
+  first tick. (To force a run against production immediately, invoke the deployed Worker's
+  scheduled handler from the Cloudflare dashboard's Cron Triggers → "Trigger" action.)
 - Point a custom domain at the `status-please-web` Worker via a route in its
   `wrangler.jsonc` or the Cloudflare dashboard.
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ bunx wrangler secret put CF_ZONE_ID     # the zone serving your status page
 When these are unset the purge is skipped (logged, not fatal) and the page simply
 refreshes on its 60s TTL.
 
-Detailed setup will land with the first release — see the [Roadmap](#roadmap).
+**Full runbook** — provisioning, config, secrets, and the manual GitHub Actions
+deploy — is in **[DEPLOYMENT.md](./DEPLOYMENT.md)**.
 
 ---
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "build": "astro build",
     "preview": "wrangler dev ./dist/_worker.js/index.js",
     "deploy": "astro build && wrangler deploy",
+    "deploy:publish": "wrangler deploy",
     "typecheck": "astro check"
   },
   "dependencies": {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -8,7 +8,9 @@
     "deploy": "wrangler deploy",
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
-    "db:apply": "wrangler d1 execute status-please --file=./schema.sql"
+    "db:apply": "wrangler d1 execute status-please --file=./schema.sql",
+    "db:apply:remote": "wrangler d1 execute status-please --remote --file=./schema.sql --yes",
+    "kv:config": "wrangler kv key put config --binding=STATUS_KV --path=../../status.config.yml --remote"
   },
   "dependencies": {
     "@status-please/core": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build": "bun run --filter '*' build",
     "lint": "eslint .",
     "typecheck": "bun run --filter '*' typecheck",
-    "test": "bun test"
+    "test": "bun test",
+    "deploy": "bun run --filter '@status-please/worker' deploy && bun run --filter '@status-please/web' deploy"
   },
   "devDependencies": {
     "@pleaseai/eslint-config": "^0.0.4",


### PR DESCRIPTION
Closes the last gap before real deployment: the repo had a CI quality gate but **no way to ship**. This adds the deploy path — manual by design, since production infra (D1/KV) and Cloudflare credentials must exist first.

## What
- **`.github/workflows/deploy.yml`** — `workflow_dispatch` only. One job that:
  1. **Preflight** — fails clearly naming any missing secret/variable.
  2. Injects account-specific **D1/KV IDs** from repo **Variables** (idempotent `sed` on the committed placeholders — a fork that commits real IDs is untouched).
  3. Applies the **D1 schema** (`--remote`, idempotent).
  4. Uploads **`status.config.yml`** to KV (`config` key).
  5. Deploys the **check Worker**, then the **status page**.
- **`DEPLOYMENT.md`** — end-to-end runbook (provision → wire IDs → config → schema → secrets → deploy locally or via Actions → troubleshooting).
- **`package.json`** — root `deploy` script (worker then web).
- **README** — links the runbook; earlier 'detailed setup will land later' note resolved.

## Security posture
- Third-party actions **SHA-pinned** (reuses CI's `checkout`/`mise-action` SHAs).
- `permissions: contents: read` only — Wrangler auths via `CLOUDFLARE_API_TOKEN`, not `GITHUB_TOKEN`, so `checkout` runs with `persist-credentials: false`.
- `environment: production` — add required-reviewer protection to gate every deploy behind approval.
- Resource IDs treated as **variables** (not secret); only the API token + account ID are secrets.
- **zizmor clean** (v1.26.1, 0 findings).

## Verification
Verified wrangler subcommand flags against wrangler `4.107.0` (`d1 execute --remote --file --yes`, `kv key put --binding --path --remote`). `bun test` (50), `lint` pass. The deploy job itself can only run with real Cloudflare credentials, so it is manual and gated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual Cloudflare deploy path that ships the worker and web to production. Hardens the workflow and adds a runbook and package scripts for safe, repeatable deploys.

- **New Features**
  - Manual `.github/workflows/deploy.yml` (`workflow_dispatch`): preflight for required secrets/vars, inject D1/KV IDs, apply D1 schema, upload `status.config.yml` to KV, then deploy the check Worker and status page. SHA-pinned actions, `contents: read`, and a `production` environment for approval gating.
  - Hardened workflow: scope `CLOUDFLARE_*` secrets to Wrangler steps only, add a 15‑minute timeout, use `|` in `sed` for ID injection, and install with `--ignore-scripts`.
  - Deployment scripts: root `deploy`, worker `db:apply:remote` and `kv:config`, web `deploy:publish`. CI calls these via `bun run` to avoid fetching unpinned packages. `DEPLOYMENT.md` is the full runbook; `README` links it.

- **Migration**
  - Set GitHub Secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`.
  - Set GitHub Variables: `CF_D1_DATABASE_ID`, `CF_KV_NAMESPACE_ID`.
  - Run the “Deploy” workflow from Actions, or `bun run deploy` locally (`@status-please/worker` then `@status-please/web`).

<sup>Written for commit 49d53fc746d7a9955c0c26820cbf388bec86c5c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual deployment workflow for publishing the worker and web app to Cloudflare.
  * Added a new deploy command to streamline local deployments.

* **Documentation**
  * Added a full deployment guide covering setup, deployment steps, post-deploy actions, and troubleshooting.
  * Updated the README to point to the new deployment guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->