### PR TITLE
build: add Turborepo for build/typecheck/dev orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ tmp/
 
 # Tool caches
 .impeccable/
+.turbo/
 
 # Review tooling transient state (thread watcher snapshots)
 .please/state/

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@pleaseai/eslint-config": "^0.0.4",
         "@types/bun": "^1.3.14",
         "eslint": "^10.6.0",
+        "turbo": "^2.10.4",
         "typescript": "^6.0",
       },
     },
@@ -540,6 +541,18 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.2", "", { "dependencies": { "@tailwindcss/node": "4.3.2", "@tailwindcss/oxide": "4.3.2", "tailwindcss": "4.3.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA=="],
+
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-m1MUEI4MJ69r5CwfMYxmHi0H0rrgiYCBOp0tgBZ9x/YVvOb5uu/lRIDyDwdtH054R2yWeQaIigUGu6aCX9f8cA=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VQ1Yxs5zkPT+2z7t1P4mvn6JmcKLkOCAsPuK9XbOvuVj0DlTlETfIXNisX0771v/vTWHOQqiwoGi+TtAUq8efw=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.4", "", { "os": "linux", "cpu": "x64" }, "sha512-IzV1QovmwX7mfGnVinmE++2IB8tbeo38weltiuH5zNqwCTBjLs/DytyRKx+bmnhHdXIq9SheR8p0Nip/LBUPHg=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-rfujSQkP5aYiRn0PgTM7F00WkJCP/bKDVZbOx3WmrZwa/vHA0bplhCl328kpX7VI9HH2vI90ISGwuSVgJgoqTw=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.4", "", { "os": "win32", "cpu": "x64" }, "sha512-NnspP7Wd5fa3Wwnqv9bKfhegqZzuHBgbPxdZU/idTLQcazx/vgKu95JlCx2YHY0hdvKCnPcARrDwM+KEUmaO7A=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Iv02YgOpaEShc2OkG7mgCJ2pEw1RUKiKbs0h8W5wAf4jZ5vpmraTEjuGTgHRuOORQnC1GN3KHo5WB+hu1abRMA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -1430,6 +1443,8 @@
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "turbo": ["turbo@2.10.4", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.4", "@turbo/darwin-arm64": "2.10.4", "@turbo/linux-64": "2.10.4", "@turbo/linux-arm64": "2.10.4", "@turbo/windows-64": "2.10.4", "@turbo/windows-arm64": "2.10.4" }, "bin": { "turbo": "bin/turbo" } }, "sha512-GQpduILaKjoaGljw097ScsSyKTtZSY7cZ3bJktzfTkPMyCf3ShKLuXK2IaOEN2Plziml+ArR7WJ1m+V4VbnaKQ=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.0",
   "private": true,
+  "packageManager": "bun@1.3.14",
   "description": "Open-source, CDN-native status page generator — a modern successor to upptime.",
   "license": "MIT",
   "repository": {
@@ -11,10 +12,10 @@
   },
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
-    "dev": "bun run --filter '@status-please/web' dev",
-    "build": "bun run --filter '*' build",
+    "dev": "turbo run dev",
+    "build": "turbo run build",
     "lint": "eslint .",
-    "typecheck": "bun run --filter '*' typecheck",
+    "typecheck": "turbo run typecheck",
     "test": "bun test",
     "deploy": "bun run --filter '@status-please/worker' deploy && bun run --filter '@status-please/web' deploy"
   },
@@ -22,6 +23,7 @@
     "@pleaseai/eslint-config": "^0.0.4",
     "@types/bun": "^1.3.14",
     "eslint": "^10.6.0",
+    "turbo": "^2.10.4",
     "typescript": "^6.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build tsconfig.build.json",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  // Build-only config: excludes tests so the emitted `dist/` carries no
+  // `*.test.js`. Type-checking (tsc --noEmit via tsconfig.json) still covers
+  // the test files.
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,6 +5,5 @@
     "types": ["bun"],
     "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,6 @@
     "types": ["bun"],
     "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "ui": "tui",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".astro/**", "*.tsbuildinfo"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    }
+  }
+}


### PR DESCRIPTION
Adds [Turborepo](https://turborepo.dev) to orchestrate the monorepo's tasks with caching and a real multi-service dev script.

## What
- **`turbo.json`**: `build` (`dependsOn: ["^build"]`, caches `dist/**`, `.astro/**`), `typecheck` (`dependsOn: ["^build"]` for correct cross-package cache invalidation), and a persistent `dev` task.
- **Root scripts** delegate to `turbo run`: `build`, `typecheck`, and `dev` — which **now runs the web + worker dev servers in parallel** (was web-only).
- **`packageManager`** pinned; **`.turbo`** gitignored.

## Deliberately left at the root (not turbo-ified)
- **`lint` = `eslint .`** — ESLint's flat config is a single-root-config tool; splitting it per-package fights that model for no gain.
- **`test` = `bun test`** — the CI script passes `--coverage --reporter=junit …` that must reach `bun test` directly (those LCOV + JUnit reports feed SonarCloud/Codecov). Wrapping it in turbo would break the arg passthrough. Bun already runs the whole suite in one fast process.

## Why `packages/core/tsconfig` excludes `*.test.ts`
core's consumers import it via the `".": "./src/index.ts"` export — **nothing reads `dist/`**. Before this, once a build populated `packages/core/dist`, the emitted `*.test.js` were picked up by the root `bun test` and **double-counted** (100 tests / 12 files). Excluding tests from the build keeps `dist` clean and the count at the correct **50 / 6**.

## Verification
- `turbo run build` warm cache → `>>> FULL TURBO` (39ms); cold 5.5s.
- `turbo run dev` starts **both** the Astro page and the Wrangler worker (local KV/D1 bindings) in parallel.
- `typecheck` (4 tasks, `^build` graph), `build` (3 tasks), `lint`, and `test` (**50/6**) all pass.
- CI is unaffected: it calls the same root scripts, and turbo installs as a devDep.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `turbo` to orchestrate monorepo builds, type checks, and dev with shared caching. Dev now runs the web and worker in parallel and speeds up builds with cache.

- **New Features**
  - `turbo.json` defines `build` (depends on `^build`, caches `dist/**`, `.astro/**`, `*.tsbuildinfo`), `typecheck` (depends on `^build`), and a persistent, non-cached `dev`.
  - Root scripts use `turbo run` for `dev`, `build`, and `typecheck`; `lint` and `test` stay at the root.
  - `.turbo/` is gitignored and `packageManager` is pinned to `bun@1.3.14`.

- **Bug Fixes**
  - Moved test-file exclusion to `packages/core/tsconfig.build.json` and updated `build` to use it. Builds no longer emit tests (prevents double-counting), while `typecheck` still covers `*.test.ts`.

<sup>Written for commit 292c5278444b751a4f1565850a0d62e8442c3200. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

