### PR TITLE
chore: add demo status.config.yml for hosted demo

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -90,7 +90,7 @@ both. Configure once:
 
 ```bash
 # Secrets (sensitive):
-gh secret set CLOUDFLARE_API_TOKEN     # token with Workers/D1/KV edit + Cache Purge
+gh secret set CLOUDFLARE_API_TOKEN     # see token requirements below
 gh secret set CLOUDFLARE_ACCOUNT_ID
 
 # Variables (resource IDs — not sensitive):
@@ -102,14 +102,34 @@ Then run it from the **Actions** tab (or `gh workflow run deploy.yml`). The job 
 `production` GitHub Environment, so you can add required-reviewer protection in repo
 settings to gate every deploy behind an approval.
 
+> **Use a User API token, not an account-owned token.** Create it under **My Profile →
+> API Tokens** (the "Edit Cloudflare Workers" template covers Workers Scripts / D1 / KV
+> Edit). An *account-owned* token fails the D1 schema step with `Authentication error
+> [code: 10000]` — `wrangler d1 execute --remote` needs `User → Memberships → Read`, a
+> User-scoped permission that account-owned tokens cannot hold. Add **Cache Purge** for
+> §6, and if you serve a **custom domain** (§8) also add **Zone → Workers Routes: Edit**
+> and **Zone → DNS: Edit** for that zone.
+
 ## 8. After the first deploy
 
 - The cron runs every 5 minutes (`triggers.crons` in `apps/worker/wrangler.jsonc`); the
   page shows sample data until the first run writes the real `summary` — just wait for the
   first tick. (To force a run against production immediately, invoke the deployed Worker's
   scheduled handler from the Cloudflare dashboard's Cron Triggers → "Trigger" action.)
-- Point a custom domain at the `status-please-web` Worker via a route in its
-  `wrangler.jsonc` or the Cloudflare dashboard.
+- Point a custom domain at the `status-please-web` Worker. If the zone is in the same
+  Cloudflare account, add a Custom Domain route to `apps/web/wrangler.jsonc` — Cloudflare
+  auto-provisions the proxied DNS record and edge cert (issuance takes a few minutes):
+
+  ```jsonc
+  "routes": [{ "pattern": "demo.status.pleaseai.dev", "custom_domain": true }]
+  ```
+
+  Two caveats: (1) adding a route **disables the `*.workers.dev` URL** — add
+  `"workers_dev": true` alongside `routes` if you want to keep it as a fallback; (2) the
+  deploy token needs **Zone → Workers Routes: Edit** and **Zone → DNS: Edit** for that
+  zone, otherwise the deploy fails on `/zones/.../workers/routes` with `code: 10000`
+  (adding a brand-new domain uses the account API and can slip through without these, but
+  *changing/removing* one needs them).
 
 ## Troubleshooting
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -120,7 +120,8 @@ settings to gate every deploy behind an approval.
   Cloudflare account, add a Custom Domain route to `apps/web/wrangler.jsonc` — Cloudflare
   auto-provisions the proxied DNS record and edge cert (issuance takes a few minutes):
 
-  ```jsonc
+  ```text
+  // in apps/web/wrangler.jsonc
   "routes": [{ "pattern": "demo.status.pleaseai.dev", "custom_domain": true }]
   ```
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_status-please&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_status-please)
 [![codecov](https://codecov.io/gh/pleaseai/status-please/graph/badge.svg)](https://codecov.io/gh/pleaseai/status-please)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Live demo](https://img.shields.io/badge/live%20demo-demo.status.pleaseai.dev-brightgreen)](https://demo.status.pleaseai.dev)
 
 > An open-source, CDN-native **status page** generator — the modern successor to [upptime](https://github.com/upptime/upptime).
+
+🔗 **Live demo:** [demo.status.pleaseai.dev](https://demo.status.pleaseai.dev) — a status-please instance monitoring a few public services, running on Cloudflare.
 
 `status-please` monitors your services, records their uptime as durable time-series
 data, and publishes a fast, good-looking status page to the edge. It keeps the parts

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -6,6 +6,11 @@
   "compatibility_date": "2026-07-01",
   "compatibility_flags": ["nodejs_compat"],
 
+  // Custom domain: Cloudflare provisions the proxied DNS record + edge cert
+  // automatically (the `pleaseai.dev` zone lives in this account). The page is
+  // still reachable at the *.workers.dev URL too.
+  "routes": [{ "pattern": "demo.status.pleaseai.dev", "custom_domain": true }],
+
   // Workers Cache: a tiered edge cache in front of this Worker. Rendered pages
   // set Cache-Control + stale-while-revalidate; hits skip the Worker and D1,
   // and concurrent requests collapse. The check Worker purges by tag on a

--- a/status.config.yml
+++ b/status.config.yml
@@ -1,0 +1,30 @@
+# Live demo config for status-please. This monitors a handful of stable public
+# endpoints so the hosted demo shows real, moving data. Not a secret — committed
+# so the deploy uploads it to the Worker's KV "config" key (see DEPLOYMENT.md §3).
+# Keep real webhook URLs out of here; set them post-deploy via secrets/KV.
+
+name: status-please Demo
+
+sites:
+  - name: GitHub API
+    url: https://api.github.com
+    check: http
+    expectedStatusCodes: [200]
+    maxResponseTime: 2000
+  - name: Cloudflare
+    url: https://www.cloudflare.com
+    check: http
+    expectedStatusCodes: [200]
+    maxResponseTime: 2000
+  - name: npm Registry
+    url: https://registry.npmjs.org
+    check: http
+    expectedStatusCodes: [200]
+    maxResponseTime: 3000
+  - name: Cloudflare DNS
+    url: https://1.1.1.1
+    check: http
+    expectedStatusCodes: [200]
+
+theme:
+  darkMode: true


### PR DESCRIPTION
Adds a committed `status.config.yml` so the Deploy workflow (`deploy.yml`) can upload it to the worker's KV `config` key and render a live demo.

Monitors stable public endpoints so the demo shows real, moving data:
- GitHub API (api.github.com)
- Cloudflare (www.cloudflare.com)
- npm Registry (registry.npmjs.org)
- Cloudflare DNS (1.1.1.1)

No secrets included — validated against `packages/core` `parseConfig`.

Part of standing up the hosted demo via GitHub Actions (method B in DEPLOYMENT.md §7).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a committed demo `status.config.yml` and serves the hosted demo at demo.status.pleaseai.dev via a custom domain; README links to it. DEPLOYMENT documents the required Cloudflare User token and custom-domain caveats, and fences the wrangler snippet for markdown lint; `deploy.yml` uploads the config to Workers KV.

- **New Features**
  - Demo config: monitors GitHub API, Cloudflare, npm Registry, and 1.1.1.1; stored in KV key `config`. No secrets; validated by core `parseConfig`.
  - Custom domain: adds a Workers Route for demo.status.pleaseai.dev.

<sup>Written for commit 8700b691a9feccc7e82cd03258e7d39cd24813c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

