### PR TITLE
ci: fix release-please token — bump create-github-app-token to v3

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
       # suppresses its events to avoid recursion). The App acts as a distinct
       # actor, so those events propagate.
       - name: Mint release-bot token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }} # org Variable


### PR DESCRIPTION
**Fixes the failed first release-please run.** The workflow errored at the token step:

```
##[warning]Unexpected input(s) 'client-id', valid inputs are ['app-id', ...]
Error: [@octokit/auth-app] appId option is required
```

`create-github-app-token@v2.2.2` doesn't accept the `client-id` input — v2 only has the now-deprecated `app-id`, so `client-id` was ignored and no app id was set. v3 adds `client-id` (and deprecates `app-id`), which is exactly the `RELEASE_BOT_CLIENT_ID` pattern the pleaseai release-bot uses.

- Bumped `actions/create-github-app-token` **v2.2.2 → v3.2.0** (SHA-pinned; verified v3.2.0's `action.yml` declares `client-id` + `permission-issues`).
- zizmor clean.

After merge, the release-please workflow re-runs on the push to main and should open the initial `chore: release 0.1.0` PR (assuming the org `RELEASE_BOT_CLIENT_ID`/`RELEASE_BOT_PRIVATE_KEY` are visible to the repo).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release-please workflow by updating `actions/create-github-app-token` from v2.2.2 to v3.2.0 to support the `client-id` input. This resolves the token step error ("appId option is required") and lets the release bot mint a token and open the initial release PR.

<sup>Written for commit c71764e858724838287225dadf3afbdee7baf4a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

