### PR TITLE
ci: use org RELEASE_GITHUB_APP credentials for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,8 +32,8 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }} # org Variable
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }} # org Secret
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }} # org Variable (ALL)
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }} # org Secret (ALL)
           # Scope the minted token to only what release-please needs, instead of
           # the App's blanket installation permissions.
           permission-contents: write


### PR DESCRIPTION
The release-please token step referenced `RELEASE_BOT_*` names that don't exist in the org. The actual pleaseai release-bot credentials are:

- `vars.RELEASE_GITHUB_APP_CLIENT_ID` (org Variable, ALL visibility)
- `secrets.RELEASE_GITHUB_APP_PRIVATE_KEY` (org Secret, ALL visibility)

Point the `create-github-app-token` step at those. Both are visible to this repo, so after merge the workflow's push-to-main run should mint the token and open the initial `chore: release 0.1.0` PR. zizmor clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `release-please` to use the org GitHub App credentials, replacing the `RELEASE_BOT_*` names. This lets the workflow mint a token and open the initial release PR on push to `main`.

- **Bug Fixes**
  - Point `actions/create-github-app-token` to `vars.RELEASE_GITHUB_APP_CLIENT_ID` and `secrets.RELEASE_GITHUB_APP_PRIVATE_KEY`.

<sup>Written for commit 611c3ee2df917436892a55447c0dbf4ffdfb5309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation credentials used by the publishing workflow, helping keep the release process aligned with the latest configuration names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->