### PR TITLE
feat(deploy): add guided setup script and Cloudflare deploy docs

### DIFF
--- a/.claude/agent-memory/review-review-code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/review-review-code-reviewer/MEMORY.md
@@ -1,3 +1,3 @@
 # Memory Index
 
-- [PR #22 setup script review](pr22-setup-script-review.md) — status-please guided deploy script: verified wrangler field names, D1/KV name-collision limitation, ask() EOF gap
+- [PR #22 setup script review](pr22-setup-script-review.md) — status-please guided deploy script: verified wrangler field names; D1/KV name-collision limitation (still open); ask() EOF gap (fixed in PR #22)

--- a/.claude/agent-memory/review-review-code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/review-review-code-reviewer/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory Index
+
+- [PR #22 setup script review](pr22-setup-script-review.md) — status-please guided deploy script: verified wrangler field names, D1/KV name-collision limitation, ask() EOF gap

--- a/.claude/agent-memory/review-review-code-reviewer/pr22-setup-script-review.md
+++ b/.claude/agent-memory/review-review-code-reviewer/pr22-setup-script-review.md
@@ -36,3 +36,15 @@ call (used for the custom-domain/cron/page-name prompts) has no EOF guard under
 does have `|| true`. Ctrl-D at one of those three prompts aborts the whole script via
 errexit instead of hitting the script's `die()` path. Minor UX issue, not a data-correctness
 bug.
+
+## Update — resolved in PR #22 (review pass 2)
+
+Most of the above was fixed in the same PR; only the collision limitation remains open:
+
+- **ask() EOF gap → FIXED.** `ask()`'s `read` now ends with `|| true`, so Ctrl-D falls
+  back to the default instead of aborting via errexit.
+- **D1/KV lookup swallow → FIXED.** `lookup_d1`/`lookup_kv` now capture only stdout and
+  return non-zero on a failed `wr` call, so the caller aborts with an auth hint instead
+  of masking the failure and taking the wrong create branch.
+- **D1/KV name-collision (account-wide match) → STILL OPEN (accepted).** Unchanged; the
+  single-deployment-per-account assumption still holds. Revisit if multi-env support lands.

--- a/.claude/agent-memory/review-review-code-reviewer/pr22-setup-script-review.md
+++ b/.claude/agent-memory/review-review-code-reviewer/pr22-setup-script-review.md
@@ -1,0 +1,38 @@
+---
+name: pr22-setup-script-review
+description: Findings from reviewing PR #22 (scripts/setup.sh + scripts/apply-config.ts guided Cloudflare deploy) — known limitations to check on follow-up PRs touching these files
+metadata:
+  type: project
+---
+
+PR #22 added `scripts/setup.sh` (bash, interactive provision+configure+deploy) and
+`scripts/apply-config.ts` (bun/TS, rewrites `apps/worker/wrangler.jsonc` and
+`apps/web/wrangler.jsonc` via targeted regex string edits to preserve JSONC comments).
+
+Reviewed against the actual wrangler CLI source (`node_modules/wrangler/wrangler-dist/cli.js`)
+rather than assumption: `d1 list --json` returns raw objects with `uuid`/`name` fields,
+`kv namespace list --json` returns raw objects with `id`/`title`; `kv namespace create <name>`
+titles the namespace as exactly `<env-prefix><name><preview-suffix>` with **no worker-name
+prefix**. The script's field assumptions (`d.uuid || d.id`, `x.title.endsWith("STATUS_KV")`)
+are correct.
+
+Known accepted limitation (flagged in review, not blocking — documented here so a future
+reviewer doesn't re-derive it from scratch): `lookup_d1`/`lookup_kv` in `scripts/setup.sh`
+match D1 databases/KV namespaces **by name only, account-wide** (`DB_NAME="status-please"`,
+KV title `endsWith("STATUS_KV")`). If a single Cloudflare account ever hosts two
+status-please deployments (e.g. a staging fork alongside prod), the second `setup.sh` run
+will silently reuse the first deployment's D1/KV resources instead of creating its own —
+there's no per-fork/per-worker namespacing in the lookup.
+
+**Why relevant:** the docs (DEPLOYMENT.md/README.md quick-start) only describe a single
+demo deployment per account, so this wasn't treated as blocking. If a future PR adds
+multi-environment support (staging/prod in one account) or the docs start recommending
+multiple deployments per account, this collision risk becomes load-bearing and should be
+revisited (e.g. namespace the D1/KV names by repo/env).
+
+Also noted (low confidence, not blocking): `scripts/setup.sh`'s `ask()` helper's `read -rp`
+call (used for the custom-domain/cron/page-name prompts) has no EOF guard under
+`set -euo pipefail`, unlike the standalone confirmation `read` later in the same file which
+does have `|| true`. Ctrl-D at one of those three prompts aborts the whole script via
+errexit instead of hitting the script's `die()` path. Minor UX issue, not a data-correctness
+bug.

--- a/.claude/agent-memory/review-review-silent-failure-hunter/MEMORY.md
+++ b/.claude/agent-memory/review-review-silent-failure-hunter/MEMORY.md
@@ -3,3 +3,4 @@
 - [status-please conventions](status_please_conventions.md) — repo's logging style (plain console.error, no Sentry/errorIds) + known intentional fail-open fallbacks in badge.ts
 - [Project error-handling conventions](project_error_conventions.md) — no Sentry/logError infra; console.error/warn is house style (see apps/worker/src/cache.ts, notify.ts)
 - [i18n feature review 2026-07](i18n_feature_2026_07.md) — amondnet/i18n branch findings: getLocale() silent catch, locale-per-URL architecture, cron Worker's redundant loud config-parse failure
+- [setup scripts error handling (PR #22)](setup_scripts_error_handling.md) — D1/KV lookup swallow (`2>/dev/null`+`|| true`) in setup.sh; apply-config.ts setNetworking warn-only fallback, setCron has none

--- a/.claude/agent-memory/review-review-silent-failure-hunter/MEMORY.md
+++ b/.claude/agent-memory/review-review-silent-failure-hunter/MEMORY.md
@@ -3,4 +3,4 @@
 - [status-please conventions](status_please_conventions.md) — repo's logging style (plain console.error, no Sentry/errorIds) + known intentional fail-open fallbacks in badge.ts
 - [Project error-handling conventions](project_error_conventions.md) — no Sentry/logError infra; console.error/warn is house style (see apps/worker/src/cache.ts, notify.ts)
 - [i18n feature review 2026-07](i18n_feature_2026_07.md) — amondnet/i18n branch findings: getLocale() silent catch, locale-per-URL architecture, cron Worker's redundant loud config-parse failure
-- [setup scripts error handling (PR #22)](setup_scripts_error_handling.md) — D1/KV lookup swallow (`2>/dev/null`+`|| true`) in setup.sh; apply-config.ts setNetworking warn-only fallback, setCron has none
+- [setup scripts error handling (PR #22)](setup_scripts_error_handling.md) — D1/KV lookup swallow + apply-config.ts setNetworking/setCron fallbacks — all fixed in PR #22 (lookups return non-zero on wr failure; setNetworking/setCron now throw)

--- a/.claude/agent-memory/review-review-silent-failure-hunter/setup_scripts_error_handling.md
+++ b/.claude/agent-memory/review-review-silent-failure-hunter/setup_scripts_error_handling.md
@@ -1,0 +1,50 @@
+---
+name: setup-scripts-error-handling
+description: Error-handling shape of scripts/setup.sh + scripts/apply-config.ts (PR #22) — D1/KV lookup swallow pattern and apply-config.ts's warn-only fallback
+metadata:
+  type: project
+---
+
+## scripts/setup.sh — D1/KV id lookup (lines ~92-126)
+
+`lookup_d1`/`lookup_kv` pipe `wr d1 list --json 2>/dev/null | bun -e '...'` and every
+call site wraps the result in `D1_ID="$(lookup_d1 || true)"`. The final
+`[ -n "$D1_ID" ] || die "..."` guards (setup.sh:114, :125) DO cover the "proceed
+with an empty id" case — script won't silently continue into deploy with a
+blank id. What they don't cover: the `2>/dev/null` + `|| true` combo discards
+*why* the lookup failed (auth expiry, rate limit, wrangler JSON shape change).
+If the first lookup transiently fails while the resource already exists, the
+script takes the "create new" branch and either hits a confusing "already
+exists" wrangler error (root cause masked) or risks creating a duplicate
+resource. Not flagged as a full silent-failure (it does eventually die/error),
+but a diagnosability + possible-duplication issue. See [[status_please_conventions]].
+
+## scripts/apply-config.ts — setNetworking warn-only fallback (line 84-85)
+
+Three-tier placement strategy (managed-block regex → shipped "Custom domain:"
+comment regex → `compatibility_flags` anchor). If all three miss, it does
+`console.warn(...)` and returns the string **unchanged** — no throw, no
+non-zero exit. `edit()` (line 29-36) treats "unchanged" as a legitimate no-op,
+so `bun scripts/apply-config.ts` exits 0 and setup.sh's `set -e` never catches
+it. setup.sh immediately prints a green "configured" ok line (setup.sh:141)
+right after, burying/contradicting the warning. Real-world trigger requires
+hand-editing wrangler.jsonc to remove the managed markers, the shipped
+"Custom domain:" comment, AND `compatibility_flags` all at once — narrow, but
+the shipped default networking value is the maintainer's own real demo domain
+(`demo.status.pleaseai.dev` in apps/web/wrangler.jsonc), so if it ever
+triggers with a user-requested custom domain, the web Worker would deploy
+under the wrong domain while the operator believes setup succeeded.
+
+`setCron` (apply-config.ts:88-93), by contrast, has *no* warning at all on
+regex-mismatch — silently leaves the old cron value. Inconsistent with
+setNetworking's (partial) diligence.
+
+**How to apply:** if scripts/setup.sh or scripts/apply-config.ts are touched
+again, check whether the warn-only fallback in setNetworking was ever changed
+to actually fail loudly (recommended fix: throw/process.exit(1) so setup.sh's
+set -e aborts before the deploy steps), and whether setCron got a matching
+warn-on-mismatch branch.
+
+kv:config / db:apply:remote / deploy steps (setup.sh:173,177,181) run without
+`|| true` under `set -euo pipefail` — failures there ARE surfaced correctly,
+confirmed by reading, not assumed.

--- a/.claude/agent-memory/review-review-silent-failure-hunter/setup_scripts_error_handling.md
+++ b/.claude/agent-memory/review-review-silent-failure-hunter/setup_scripts_error_handling.md
@@ -48,3 +48,15 @@ warn-on-mismatch branch.
 kv:config / db:apply:remote / deploy steps (setup.sh:173,177,181) run without
 `|| true` under `set -euo pipefail` — failures there ARE surfaced correctly,
 confirmed by reading, not assumed.
+
+## Update — all three resolved in PR #22 (review pass 2)
+
+The behavior described above is the pre-fix state. Current code:
+
+- **D1/KV lookup swallow → FIXED.** `lookup_d1`/`lookup_kv` capture only stdout and
+  `return 1` on a non-zero `wr` exit; the call sites dropped `|| true` and `die` with an
+  auth hint. A failed wrangler call now aborts instead of being misread as "not found".
+- **setNetworking warn-only fallback → FIXED.** The all-three-miss branch now `throw`s,
+  so setup.sh's `set -e` aborts before the deploy steps instead of shipping the demo domain.
+- **setCron no-warning → FIXED.** `setCron` now `throw`s on a shape mismatch too, matching
+  setNetworking. A dropped schedule can no longer look applied.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -8,6 +8,28 @@ snapshot at the edge, fronted by Workers Cache.
 This guide takes you from an empty Cloudflare account to a live status page, then wires
 the manual GitHub Actions deploy for repeat deploys.
 
+## Quick start (scripted)
+
+The monorepo can't use a one-click "Deploy to Cloudflare" button (two Workers + a shared
+workspace package), so there's a guided script instead. After cloning your fork:
+
+```bash
+mise trust && mise install && bun install
+bunx wrangler login          # or export CLOUDFLARE_API_TOKEN
+bun run setup                # provisions, prompts, configures, deploys
+```
+
+`bun run setup` runs everything below for you, idempotently: it provisions D1 + KV,
+asks a couple of wrangler questions (custom domain, cron schedule), wires the resource
+IDs and your answers into both `wrangler.jsonc` files, seeds `status.config.yml`, applies
+the schema, uploads the config, and deploys both Workers. Flags: `--skip-deploy`
+(provision + configure only) and `--yes` (non-interactive, accept every default). Re-run
+it any time to change the domain/cron or redeploy. Commit the updated `wrangler.jsonc`
+and `status.config.yml` to your fork afterwards.
+
+The rest of this document is the **manual** path — do it by hand, or read it to
+understand exactly what the script does.
+
 ## Prerequisites
 
 - A Cloudflare account (any plan — [cache purge-by-tag is available on all plans](https://developers.cloudflare.com/changelog/post/2025-04-01-purge-for-all/) since April 2025).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![codecov](https://codecov.io/gh/pleaseai/status-please/graph/badge.svg)](https://codecov.io/gh/pleaseai/status-please)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![Live demo](https://img.shields.io/badge/live%20demo-demo.status.pleaseai.dev-brightgreen)](https://demo.status.pleaseai.dev)
+[![Deploy on Cloudflare](https://img.shields.io/badge/deploy%20on-Cloudflare-F38020?logo=cloudflare&logoColor=white)](./DEPLOYMENT.md)
 
 > An open-source, CDN-native **status page** generator — the modern successor to [upptime](https://github.com/upptime/upptime).
 
@@ -250,6 +251,22 @@ Both send `Access-Control-Allow-Origin: *`, so a browser can fetch them directly
 `status-please` deploys to any Cloudflare account (Workers + D1 + KV + Pages). Vercel
 is also supported for the display layer via Astro's Vercel adapter.
 
+**Fastest path — the guided script.** A one-click "Deploy to Cloudflare" button can't
+handle this monorepo (two Workers + a shared workspace package), so `bun run setup` is
+the equivalent: it provisions D1 + KV, interactively asks for your custom domain and cron
+schedule, wires them into both `wrangler.jsonc` files, seeds `status.config.yml`, and
+deploys both Workers — all idempotent, safe to re-run.
+
+```bash
+# after cloning your fork
+bunx wrangler login   # or export CLOUDFLARE_API_TOKEN
+bun install
+bun run setup         # -- --skip-deploy to configure without deploying
+```
+
+<details>
+<summary>Prefer to do it by hand?</summary>
+
 ```bash
 # 1. Use this template / clone it
 # 2. Provision Cloudflare resources
@@ -260,6 +277,8 @@ bunx wrangler kv namespace create STATUS_KV
 bun install
 bun run deploy
 ```
+
+</details>
 
 ### Instant cache invalidation (optional)
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint .",
     "typecheck": "turbo run typecheck",
     "test": "bun test",
+    "setup": "bash scripts/setup.sh",
     "deploy": "bun run --filter '@status-please/worker' deploy && bun run --filter '@status-please/web' deploy"
   },
   "devDependencies": {

--- a/scripts/apply-config.ts
+++ b/scripts/apply-config.ts
@@ -113,10 +113,12 @@ function setCron(s: string): string {
   // Replace the single expression inside "crons": [ "..." ].
   const re = /("crons"\s*:\s*\[\s*)"[^"]*"(\s*\])/
   if (!re.test(s)) {
-    // Non-fatal (the committed default cron still works), but warn so a silently
-    // dropped schedule doesn't look applied.
-    console.warn(`  warning: could not set the cron expression in ${WORKER}; edit it by hand`)
-    return s
+    // Fail loud, like setNetworking: silently returning the input would let
+    // setup.sh report success while the user's chosen schedule was dropped.
+    throw new Error(
+      `could not set the cron expression in ${WORKER} ("crons" array not found in `
+      + `the expected shape). Edit it by hand, then re-run.`,
+    )
   }
   return s.replace(re, (_m, p1, p2) => `${p1}${JSON.stringify(cron)}${p2}`)
 }

--- a/scripts/apply-config.ts
+++ b/scripts/apply-config.ts
@@ -13,34 +13,41 @@
  *   CRON                 replace the worker's cron expression (worker file)
  *
  * Every edit is a no-op when the target already matches, so re-running setup is
- * safe.
+ * safe. All replacements that splice in an external value use a replacer
+ * function, never a replacement string, so a `$` in the value (`$&`, `$1`, …)
+ * can't be misread as a special pattern.
  */
+import process from 'node:process'
 
-const WORKER = "apps/worker/wrangler.jsonc";
-const WEB = "apps/web/wrangler.jsonc";
+const WORKER = 'apps/worker/wrangler.jsonc'
+const WEB = 'apps/web/wrangler.jsonc'
 
 // Markers wrap the managed networking block so re-runs find and replace exactly
 // what a previous run wrote, regardless of which branch it took.
-const MARK_START = "// >>> networking (managed by scripts/setup.sh) >>>";
-const MARK_END = "// <<< networking (managed by scripts/setup.sh) <<<";
+const MARK_START = '// >>> networking (managed by scripts/setup.sh) >>>'
+const MARK_END = '// <<< networking (managed by scripts/setup.sh) <<<'
 
-const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const esc = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 async function edit(path: string, fn: (s: string) => string): Promise<void> {
-  const before = await Bun.file(path).text();
-  const after = fn(before);
+  const before = await Bun.file(path).text()
+  const after = fn(before)
   if (after !== before) {
-    await Bun.write(path, after);
-    console.log(`  updated ${path}`);
+    await Bun.write(path, after)
+    console.log(`  updated ${path}`)
   }
 }
 
 function injectIds(s: string): string {
-  const d1 = process.env.D1_ID;
-  const kv = process.env.KV_ID;
-  if (d1) s = s.replaceAll("REPLACE_WITH_D1_DATABASE_ID", d1);
-  if (kv) s = s.replaceAll("REPLACE_WITH_KV_NAMESPACE_ID", kv);
-  return s;
+  const d1 = process.env.D1_ID
+  const kv = process.env.KV_ID
+  if (d1) {
+    s = s.replaceAll('REPLACE_WITH_D1_DATABASE_ID', () => d1)
+  }
+  if (kv) {
+    s = s.replaceAll('REPLACE_WITH_KV_NAMESPACE_ID', () => kv)
+  }
+  return s
 }
 
 function networkingBlock(domain: string): string {
@@ -53,7 +60,7 @@ function networkingBlock(domain: string): string {
       `  "routes": [{ "pattern": ${JSON.stringify(domain)}, "custom_domain": true }],`,
       `  "workers_dev": true,`,
       `  ${MARK_END}`,
-    ].join("\n");
+    ].join('\n')
   }
   return [
     `  ${MARK_START}`,
@@ -61,48 +68,58 @@ function networkingBlock(domain: string): string {
     `  // URL. Re-run scripts/setup.sh to attach a custom domain later.`,
     `  "workers_dev": true,`,
     `  ${MARK_END}`,
-  ].join("\n");
+  ].join('\n')
 }
 
 function setNetworking(s: string): string {
-  if (process.env.SET_NETWORKING !== "1") return s;
-  const block = networkingBlock(process.env.CUSTOM_DOMAIN ?? "");
+  if (process.env.SET_NETWORKING !== '1') {
+    return s
+  }
+  const block = networkingBlock(process.env.CUSTOM_DOMAIN ?? '')
 
   // A managed block already present → replace it.
-  const managed = new RegExp(`[ \\t]*${esc(MARK_START)}[\\s\\S]*?${esc(MARK_END)}`);
-  if (managed.test(s)) return s.replace(managed, block);
+  const managed = new RegExp(`[ \\t]*${esc(MARK_START)}[\\s\\S]*?${esc(MARK_END)}`)
+  if (managed.test(s)) {
+    return s.replace(managed, () => block)
+  }
 
   // First run: replace the shipped "Custom domain:" comment + routes line.
-  const shipped = /[ \t]*\/\/ Custom domain:[\s\S]*?"routes"\s*:\s*\[[\s\S]*?\],/;
-  if (shipped.test(s)) return s.replace(shipped, block);
+  const shipped = /[ \t]*\/\/ Custom domain:[\s\S]*?"routes"\s*:\s*\[[\s\S]*?\],/
+  if (shipped.test(s)) {
+    return s.replace(shipped, () => block)
+  }
 
   // Neither present (e.g. routes were hand-removed): insert after the
   // compatibility_flags line, a stable anchor in both files.
-  const anchor = /("compatibility_flags"\s*:\s*\[[^\]]*\],)/;
-  if (anchor.test(s)) return s.replace(anchor, `$1\n\n${block}`);
+  const anchor = /("compatibility_flags"\s*:\s*\[[^\]]*\],)/
+  if (anchor.test(s)) {
+    return s.replace(anchor, (_m, p1) => `${p1}\n\n${block}`)
+  }
 
   // Fail loud rather than return `s` unchanged: a silent no-op here would let
   // setup.sh print "✓ configured" and then deploy the web Worker with the
   // shipped demo domain (or a stale route) instead of the requested one.
   throw new Error(
-    `could not place the networking block in ${WEB} (no marker, "// Custom domain:" ` +
-      `comment, or compatibility_flags anchor found). Edit it by hand, then re-run.`,
-  );
+    `could not place the networking block in ${WEB} (no marker, "// Custom domain:" `
+    + `comment, or compatibility_flags anchor found). Edit it by hand, then re-run.`,
+  )
 }
 
 function setCron(s: string): string {
-  const cron = process.env.CRON;
-  if (!cron) return s;
+  const cron = process.env.CRON
+  if (!cron) {
+    return s
+  }
   // Replace the single expression inside "crons": [ "..." ].
-  const re = /("crons"\s*:\s*\[\s*)"[^"]*"(\s*\])/;
+  const re = /("crons"\s*:\s*\[\s*)"[^"]*"(\s*\])/
   if (!re.test(s)) {
     // Non-fatal (the committed default cron still works), but warn so a silently
     // dropped schedule doesn't look applied.
-    console.warn(`  warning: could not set the cron expression in ${WORKER}; edit it by hand`);
-    return s;
+    console.warn(`  warning: could not set the cron expression in ${WORKER}; edit it by hand`)
+    return s
   }
-  return s.replace(re, `$1${JSON.stringify(cron)}$2`);
+  return s.replace(re, (_m, p1, p2) => `${p1}${JSON.stringify(cron)}${p2}`)
 }
 
-await edit(WORKER, (s) => setCron(injectIds(s)));
-await edit(WEB, (s) => setNetworking(injectIds(s)));
+await edit(WORKER, s => setCron(injectIds(s)))
+await edit(WEB, s => setNetworking(injectIds(s)))

--- a/scripts/apply-config.ts
+++ b/scripts/apply-config.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+/**
+ * apply-config.ts — write account-specific settings into the two wrangler.jsonc
+ * files, idempotently and without disturbing their comments.
+ *
+ * Driven entirely by env vars so `scripts/setup.sh` stays the single source of
+ * prompts. JSONC keeps comments, so we do targeted string edits (not JSON
+ * parse/stringify, which would strip them):
+ *
+ *   D1_ID / KV_ID        replace the committed REPLACE_WITH_* placeholders (both files)
+ *   SET_NETWORKING=1     rewrite the web app's networking block from CUSTOM_DOMAIN
+ *                        (a value → custom-domain route; empty → *.workers.dev)
+ *   CRON                 replace the worker's cron expression (worker file)
+ *
+ * Every edit is a no-op when the target already matches, so re-running setup is
+ * safe.
+ */
+
+const WORKER = "apps/worker/wrangler.jsonc";
+const WEB = "apps/web/wrangler.jsonc";
+
+// Markers wrap the managed networking block so re-runs find and replace exactly
+// what a previous run wrote, regardless of which branch it took.
+const MARK_START = "// >>> networking (managed by scripts/setup.sh) >>>";
+const MARK_END = "// <<< networking (managed by scripts/setup.sh) <<<";
+
+const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+async function edit(path: string, fn: (s: string) => string): Promise<void> {
+  const before = await Bun.file(path).text();
+  const after = fn(before);
+  if (after !== before) {
+    await Bun.write(path, after);
+    console.log(`  updated ${path}`);
+  }
+}
+
+function injectIds(s: string): string {
+  const d1 = process.env.D1_ID;
+  const kv = process.env.KV_ID;
+  if (d1) s = s.replaceAll("REPLACE_WITH_D1_DATABASE_ID", d1);
+  if (kv) s = s.replaceAll("REPLACE_WITH_KV_NAMESPACE_ID", kv);
+  return s;
+}
+
+function networkingBlock(domain: string): string {
+  if (domain) {
+    return [
+      `  ${MARK_START}`,
+      `  // Custom domain: Cloudflare provisions the proxied DNS record + edge`,
+      `  // cert automatically (the zone must live in this Cloudflare account).`,
+      `  // "workers_dev" keeps the generated *.workers.dev URL as a fallback.`,
+      `  "routes": [{ "pattern": ${JSON.stringify(domain)}, "custom_domain": true }],`,
+      `  "workers_dev": true,`,
+      `  ${MARK_END}`,
+    ].join("\n");
+  }
+  return [
+    `  ${MARK_START}`,
+    `  // No custom domain: the page is served from the generated *.workers.dev`,
+    `  // URL. Re-run scripts/setup.sh to attach a custom domain later.`,
+    `  "workers_dev": true,`,
+    `  ${MARK_END}`,
+  ].join("\n");
+}
+
+function setNetworking(s: string): string {
+  if (process.env.SET_NETWORKING !== "1") return s;
+  const block = networkingBlock(process.env.CUSTOM_DOMAIN ?? "");
+
+  // A managed block already present → replace it.
+  const managed = new RegExp(`[ \\t]*${esc(MARK_START)}[\\s\\S]*?${esc(MARK_END)}`);
+  if (managed.test(s)) return s.replace(managed, block);
+
+  // First run: replace the shipped "Custom domain:" comment + routes line.
+  const shipped = /[ \t]*\/\/ Custom domain:[\s\S]*?"routes"\s*:\s*\[[\s\S]*?\],/;
+  if (shipped.test(s)) return s.replace(shipped, block);
+
+  // Neither present (e.g. routes were hand-removed): insert after the
+  // compatibility_flags line, a stable anchor in both files.
+  const anchor = /("compatibility_flags"\s*:\s*\[[^\]]*\],)/;
+  if (anchor.test(s)) return s.replace(anchor, `$1\n\n${block}`);
+
+  console.warn(`  warning: could not place networking block in ${WEB}; edit it by hand`);
+  return s;
+}
+
+function setCron(s: string): string {
+  const cron = process.env.CRON;
+  if (!cron) return s;
+  // Replace the single expression inside "crons": [ "..." ].
+  return s.replace(/("crons"\s*:\s*\[\s*)"[^"]*"(\s*\])/, `$1${JSON.stringify(cron)}$2`);
+}
+
+await edit(WORKER, (s) => setCron(injectIds(s)));
+await edit(WEB, (s) => setNetworking(injectIds(s)));

--- a/scripts/apply-config.ts
+++ b/scripts/apply-config.ts
@@ -81,15 +81,27 @@ function setNetworking(s: string): string {
   const anchor = /("compatibility_flags"\s*:\s*\[[^\]]*\],)/;
   if (anchor.test(s)) return s.replace(anchor, `$1\n\n${block}`);
 
-  console.warn(`  warning: could not place networking block in ${WEB}; edit it by hand`);
-  return s;
+  // Fail loud rather than return `s` unchanged: a silent no-op here would let
+  // setup.sh print "✓ configured" and then deploy the web Worker with the
+  // shipped demo domain (or a stale route) instead of the requested one.
+  throw new Error(
+    `could not place the networking block in ${WEB} (no marker, "// Custom domain:" ` +
+      `comment, or compatibility_flags anchor found). Edit it by hand, then re-run.`,
+  );
 }
 
 function setCron(s: string): string {
   const cron = process.env.CRON;
   if (!cron) return s;
   // Replace the single expression inside "crons": [ "..." ].
-  return s.replace(/("crons"\s*:\s*\[\s*)"[^"]*"(\s*\])/, `$1${JSON.stringify(cron)}$2`);
+  const re = /("crons"\s*:\s*\[\s*)"[^"]*"(\s*\])/;
+  if (!re.test(s)) {
+    // Non-fatal (the committed default cron still works), but warn so a silently
+    // dropped schedule doesn't look applied.
+    console.warn(`  warning: could not set the cron expression in ${WORKER}; edit it by hand`);
+    return s;
+  }
+  return s.replace(re, `$1${JSON.stringify(cron)}$2`);
 }
 
 await edit(WORKER, (s) => setCron(injectIds(s)));

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -112,7 +112,7 @@ lookup_d1() {
       const a = JSON.parse(text);
       const d = Array.isArray(a) ? a.find(x => x.name === process.env.DB_NAME) : null;
       process.stdout.write(d ? String(d.uuid || d.id || "") : "");
-    } catch { process.exit(0); }
+    } catch { process.exit(1); } // non-empty but unparseable → fail, do not misread as "not found"
   '
 }
 lookup_kv() {
@@ -125,7 +125,7 @@ lookup_kv() {
       const a = JSON.parse(text);
       const k = Array.isArray(a) ? a.find(x => String(x.title || "").endsWith("STATUS_KV")) : null;
       process.stdout.write(k ? String(k.id) : "");
-    } catch { process.exit(0); }
+    } catch { process.exit(1); } // non-empty but unparseable → fail, do not misread as "not found"
   '
 }
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -69,7 +69,9 @@ die()  { printf '\n%s✗ %s%s\n' "$RED" "$1" "$RST" >&2; exit 1; }
 ask() { # ask <prompt> <default> <var>
   local prompt="$1" def="$2" __var="$3" reply
   if [ "$INTERACTIVE" -eq 0 ]; then printf -v "$__var" '%s' "$def"; return; fi
-  if [ -n "$def" ]; then read -rp "  $prompt [$def]: " reply; else read -rp "  $prompt: " reply; fi
+  # `|| true`: a closed stdin / Ctrl-D returns non-zero from read; fall back to
+  # the default instead of aborting the whole script via `set -e`.
+  if [ -n "$def" ]; then read -rp "  $prompt [$def]: " reply || true; else read -rp "  $prompt: " reply || true; fi
   printf -v "$__var" '%s' "${reply:-$def}"
 }
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,6 +29,7 @@ SKIP_DEPLOY=0
 
 for arg in "$@"; do
   case "$arg" in
+    --) ;;  # bare separator (e.g. from `bash scripts/setup.sh -- --yes`) — ignore
     -y|--yes) ASSUME_YES=1 ;;
     --skip-deploy) SKIP_DEPLOY=1 ;;
     -h|--help)
@@ -93,12 +94,18 @@ ok "bun + Cloudflare auth ready"
 # --- 1. provision D1 + KV (idempotent) -------------------------------------
 step "Provisioning D1 + KV"
 
+# Distinguish "wrangler call failed" from "resource not found":
+#   - capture only stdout (the JSON); a non-zero wrangler exit (expired auth,
+#     network, API error) makes the function return non-zero so the caller can
+#     abort, instead of the failure being masked and misread as "not found"
+#     (which would take the wrong create-a-duplicate branch).
+#   - a successful-but-empty/unparseable result → empty stdout, exit 0 → the
+#     caller's `-n` check drives the create path. The JSON.parse is still guarded
+#     so a surprising payload can't dump a Bun stack trace.
 lookup_d1() {
-  # Guard the JSON parse: a failed/empty `wr d1 list` yields "" here, and an
-  # unguarded JSON.parse("") would dump a Bun stack trace to stderr. Treat any
-  # parse/empty case as "not found" (empty stdout) — the caller's `-n` check
-  # then drives the create-or-die path.
-  wr d1 list --json 2>/dev/null | DB_NAME="$DB_NAME" bun -e '
+  local json
+  json="$(wr d1 list --json 2>/dev/null)" || return 1
+  printf '%s' "$json" | DB_NAME="$DB_NAME" bun -e '
     try {
       const text = (await Bun.stdin.text()).trim();
       if (!text) process.exit(0);
@@ -109,7 +116,9 @@ lookup_d1() {
   '
 }
 lookup_kv() {
-  wr kv namespace list --json 2>/dev/null | bun -e '
+  local json
+  json="$(wr kv namespace list --json 2>/dev/null)" || return 1
+  printf '%s' "$json" | bun -e '
     try {
       const text = (await Bun.stdin.text()).trim();
       if (!text) process.exit(0);
@@ -120,21 +129,23 @@ lookup_kv() {
   '
 }
 
-D1_ID="$(lookup_d1 || true)"
+AUTH_HINT="check your Cloudflare auth ('bunx wrangler login' or CLOUDFLARE_API_TOKEN) and retry"
+
+D1_ID="$(lookup_d1)" || die "Could not query D1 (wrangler d1 list failed) — $AUTH_HINT."
 if [ -z "$D1_ID" ]; then
   info "Creating D1 database '$DB_NAME'…"; wr d1 create "$DB_NAME" >/dev/null
-  D1_ID="$(lookup_d1 || true)"
+  D1_ID="$(lookup_d1)" || die "Could not query D1 after create — $AUTH_HINT."
 else
   info "D1 '$DB_NAME' already exists — reusing."
 fi
 [ -n "$D1_ID" ] || die "Could not determine the D1 database id."
 ok "D1 database_id: $D1_ID"
 
-KV_ID="$(lookup_kv || true)"
+KV_ID="$(lookup_kv)" || die "Could not query KV (wrangler kv namespace list failed) — $AUTH_HINT."
 if [ -z "$KV_ID" ]; then
   info "Creating KV namespace 'STATUS_KV'…"
   wr kv namespace create STATUS_KV --config apps/worker/wrangler.jsonc >/dev/null
-  KV_ID="$(lookup_kv || true)"
+  KV_ID="$(lookup_kv)" || die "Could not query KV after create — $AUTH_HINT."
 else
   info "KV namespace 'STATUS_KV' already exists — reusing."
 fi
@@ -168,9 +179,11 @@ else
   if [ -n "$PAGE_NAME" ]; then
     PAGE_NAME="$PAGE_NAME" bun -e '
       let s = await Bun.file("status.config.yml").text();
-      // Replacer function, not a string: a "$" in the name (e.g. "A$AP Status")
-      // would otherwise be read as a $-pattern by String.replace.
-      s = s.replace(/^name:.*$/m, () => "name: " + process.env.PAGE_NAME);
+      // JSON.stringify → a double-quoted YAML scalar, so a name containing ":",
+      // "#", a leading "@", or quotes stays valid YAML. Passing it via a
+      // replacer function (not a string) also keeps a "$" from being read as a
+      // $-pattern by String.replace.
+      s = s.replace(/^name:.*$/m, () => "name: " + JSON.stringify(process.env.PAGE_NAME));
       await Bun.write("status.config.yml", s);
     '
   fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -81,7 +81,9 @@ wr() { bunx wrangler "$@"; }  # workspace-local wrangler, no global install need
 step "Checking prerequisites"
 command -v bun >/dev/null 2>&1 || die "bun is not installed — see https://bun.sh"
 if [ ! -d node_modules ]; then
-  info "Installing workspace dependencies…"; bun install
+  # --ignore-scripts: don't run dependency lifecycle scripts on install (matches
+  # the CI deploy). The build + wrangler bundling don't need them.
+  info "Installing workspace dependencies…"; bun install --ignore-scripts
 fi
 if ! wr whoami >/dev/null 2>&1; then
   die "Not authenticated with Cloudflare. Run 'bunx wrangler login' (or export CLOUDFLARE_API_TOKEN) and re-run."
@@ -92,17 +94,29 @@ ok "bun + Cloudflare auth ready"
 step "Provisioning D1 + KV"
 
 lookup_d1() {
+  # Guard the JSON parse: a failed/empty `wr d1 list` yields "" here, and an
+  # unguarded JSON.parse("") would dump a Bun stack trace to stderr. Treat any
+  # parse/empty case as "not found" (empty stdout) — the caller's `-n` check
+  # then drives the create-or-die path.
   wr d1 list --json 2>/dev/null | DB_NAME="$DB_NAME" bun -e '
-    const a = JSON.parse(await Bun.stdin.text());
-    const d = Array.isArray(a) ? a.find(x => x.name === process.env.DB_NAME) : null;
-    process.stdout.write(d ? String(d.uuid || d.id || "") : "");
+    try {
+      const text = (await Bun.stdin.text()).trim();
+      if (!text) process.exit(0);
+      const a = JSON.parse(text);
+      const d = Array.isArray(a) ? a.find(x => x.name === process.env.DB_NAME) : null;
+      process.stdout.write(d ? String(d.uuid || d.id || "") : "");
+    } catch { process.exit(0); }
   '
 }
 lookup_kv() {
   wr kv namespace list --json 2>/dev/null | bun -e '
-    const a = JSON.parse(await Bun.stdin.text());
-    const k = Array.isArray(a) ? a.find(x => String(x.title || "").endsWith("STATUS_KV")) : null;
-    process.stdout.write(k ? String(k.id) : "");
+    try {
+      const text = (await Bun.stdin.text()).trim();
+      if (!text) process.exit(0);
+      const a = JSON.parse(text);
+      const k = Array.isArray(a) ? a.find(x => String(x.title || "").endsWith("STATUS_KV")) : null;
+      process.stdout.write(k ? String(k.id) : "");
+    } catch { process.exit(0); }
   '
 }
 
@@ -154,7 +168,9 @@ else
   if [ -n "$PAGE_NAME" ]; then
     PAGE_NAME="$PAGE_NAME" bun -e '
       let s = await Bun.file("status.config.yml").text();
-      s = s.replace(/^name:.*$/m, "name: " + process.env.PAGE_NAME);
+      // Replacer function, not a string: a "$" in the name (e.g. "A$AP Status")
+      // would otherwise be read as a $-pattern by String.replace.
+      s = s.replace(/^name:.*$/m, () => "name: " + process.env.PAGE_NAME);
       await Bun.write("status.config.yml", s);
     '
   fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# setup.sh — interactive one-shot setup + deploy for a status-please fork.
+#
+# The "Deploy to Cloudflare" button can't deploy this monorepo (two Workers +
+# a shared workspace package), so this script is the guided alternative. It
+# walks DEPLOYMENT.md §1–7 for a local operator: provisions D1 + KV, asks a
+# couple of wrangler questions (custom domain, cron), wires everything into the
+# committed config, applies the schema, uploads your config, and deploys both
+# Workers. Every step is idempotent — safe to re-run.
+#
+# Usage:
+#   bun run setup                 # interactive
+#   bun run setup -- --yes        # non-interactive, accept every default
+#   bun run setup -- --skip-deploy  # provision + configure only, don't deploy
+#
+# Prereqs: bun, and Cloudflare auth (`bunx wrangler login`, or export
+# CLOUDFLARE_API_TOKEN [+ CLOUDFLARE_ACCOUNT_ID if the token spans accounts]).
+
+set -euo pipefail
+
+# --- run from the repo root regardless of where it's invoked ---------------
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+DB_NAME="status-please"
+ASSUME_YES=0
+SKIP_DEPLOY=0
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) ASSUME_YES=1 ;;
+    --skip-deploy) SKIP_DEPLOY=1 ;;
+    -h|--help)
+      cat <<'USAGE'
+setup.sh — interactive setup + deploy for a status-please fork.
+
+Provisions D1 + KV, asks a couple of wrangler questions (custom domain, cron),
+wires everything into the committed config, applies the D1 schema, uploads your
+status.config.yml, and deploys both Workers. Every step is idempotent.
+
+Usage:
+  bun run setup                    # interactive
+  bun run setup -- --yes           # non-interactive, accept every default
+  bun run setup -- --skip-deploy   # provision + configure only, don't deploy
+
+Prereqs: bun, and Cloudflare auth (`bunx wrangler login`, or export
+CLOUDFLARE_API_TOKEN [+ CLOUDFLARE_ACCOUNT_ID if the token spans accounts]).
+USAGE
+      exit 0 ;;
+    *) echo "Unknown option: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+# Interactive only on a real TTY and when the user hasn't opted out.
+INTERACTIVE=0
+if [ "$ASSUME_YES" -eq 0 ] && [ -t 0 ]; then INTERACTIVE=1; fi
+
+# --- pretty logging --------------------------------------------------------
+if [ -t 1 ]; then B=$'\033[1m'; DIM=$'\033[2m'; GRN=$'\033[32m'; YLW=$'\033[33m'; RED=$'\033[31m'; RST=$'\033[0m'
+else B=""; DIM=""; GRN=""; YLW=""; RED=""; RST=""; fi
+STEP=0
+step() { STEP=$((STEP + 1)); printf '\n%s▸ %s. %s%s\n' "$B" "$STEP" "$1" "$RST"; }
+info() { printf '  %s\n' "$1"; }
+ok()   { printf '  %s✓ %s%s\n' "$GRN" "$1" "$RST"; }
+warn() { printf '  %s! %s%s\n' "$YLW" "$1" "$RST"; }
+die()  { printf '\n%s✗ %s%s\n' "$RED" "$1" "$RST" >&2; exit 1; }
+
+ask() { # ask <prompt> <default> <var>
+  local prompt="$1" def="$2" __var="$3" reply
+  if [ "$INTERACTIVE" -eq 0 ]; then printf -v "$__var" '%s' "$def"; return; fi
+  if [ -n "$def" ]; then read -rp "  $prompt [$def]: " reply; else read -rp "  $prompt: " reply; fi
+  printf -v "$__var" '%s' "${reply:-$def}"
+}
+
+wr() { bunx wrangler "$@"; }  # workspace-local wrangler, no global install needed
+
+# --- 0. prerequisites ------------------------------------------------------
+step "Checking prerequisites"
+command -v bun >/dev/null 2>&1 || die "bun is not installed — see https://bun.sh"
+if [ ! -d node_modules ]; then
+  info "Installing workspace dependencies…"; bun install
+fi
+if ! wr whoami >/dev/null 2>&1; then
+  die "Not authenticated with Cloudflare. Run 'bunx wrangler login' (or export CLOUDFLARE_API_TOKEN) and re-run."
+fi
+ok "bun + Cloudflare auth ready"
+
+# --- 1. provision D1 + KV (idempotent) -------------------------------------
+step "Provisioning D1 + KV"
+
+lookup_d1() {
+  wr d1 list --json 2>/dev/null | DB_NAME="$DB_NAME" bun -e '
+    const a = JSON.parse(await Bun.stdin.text());
+    const d = Array.isArray(a) ? a.find(x => x.name === process.env.DB_NAME) : null;
+    process.stdout.write(d ? String(d.uuid || d.id || "") : "");
+  '
+}
+lookup_kv() {
+  wr kv namespace list --json 2>/dev/null | bun -e '
+    const a = JSON.parse(await Bun.stdin.text());
+    const k = Array.isArray(a) ? a.find(x => String(x.title || "").endsWith("STATUS_KV")) : null;
+    process.stdout.write(k ? String(k.id) : "");
+  '
+}
+
+D1_ID="$(lookup_d1 || true)"
+if [ -z "$D1_ID" ]; then
+  info "Creating D1 database '$DB_NAME'…"; wr d1 create "$DB_NAME" >/dev/null
+  D1_ID="$(lookup_d1 || true)"
+else
+  info "D1 '$DB_NAME' already exists — reusing."
+fi
+[ -n "$D1_ID" ] || die "Could not determine the D1 database id."
+ok "D1 database_id: $D1_ID"
+
+KV_ID="$(lookup_kv || true)"
+if [ -z "$KV_ID" ]; then
+  info "Creating KV namespace 'STATUS_KV'…"
+  wr kv namespace create STATUS_KV --config apps/worker/wrangler.jsonc >/dev/null
+  KV_ID="$(lookup_kv || true)"
+else
+  info "KV namespace 'STATUS_KV' already exists — reusing."
+fi
+[ -n "$KV_ID" ] || die "Could not determine the KV namespace id."
+ok "KV namespace id: $KV_ID"
+
+# --- 2. wrangler settings (interactive) ------------------------------------
+step "Wrangler settings"
+CUSTOM_DOMAIN=""
+ask "Custom domain for the status page (blank = use *.workers.dev)" "" CUSTOM_DOMAIN
+CRON=""
+ask "Cron schedule for checks" "*/5 * * * *" CRON
+if [ -n "$CUSTOM_DOMAIN" ]; then info "Domain: $CUSTOM_DOMAIN"; else info "No custom domain — the page will use its *.workers.dev URL."; fi
+info "Cron:   $CRON"
+
+step "Writing settings into wrangler.jsonc"
+D1_ID="$D1_ID" KV_ID="$KV_ID" CRON="$CRON" \
+  SET_NETWORKING=1 CUSTOM_DOMAIN="$CUSTOM_DOMAIN" \
+  bun scripts/apply-config.ts
+ok "apps/worker + apps/web wrangler.jsonc configured"
+
+# --- 3. status.config.yml --------------------------------------------------
+step "Your service list (status.config.yml)"
+if [ -f status.config.yml ]; then
+  info "status.config.yml already exists — leaving it untouched."
+else
+  cp status.config.example.yml status.config.yml
+  ok "Created status.config.yml from the example."
+  PAGE_NAME=""
+  ask "Status page name" "Acme Status" PAGE_NAME
+  if [ -n "$PAGE_NAME" ]; then
+    PAGE_NAME="$PAGE_NAME" bun -e '
+      let s = await Bun.file("status.config.yml").text();
+      s = s.replace(/^name:.*$/m, "name: " + process.env.PAGE_NAME);
+      await Bun.write("status.config.yml", s);
+    '
+  fi
+  if [ "$INTERACTIVE" -eq 1 ]; then
+    warn "Edit status.config.yml now and list the services you want to monitor."
+    read -rp "  Press Enter when it's ready (Ctrl-C to abort)… " _ || true
+  fi
+fi
+
+if [ "$SKIP_DEPLOY" -eq 1 ]; then
+  step "Done (setup only)"
+  ok "Provisioned + configured. Run 'bun run deploy' when you're ready to ship."
+  exit 0
+fi
+
+# --- 4. deploy (reuses the same tasks CI runs) -----------------------------
+step "Applying the D1 schema"
+bun run --filter '@status-please/worker' db:apply:remote
+ok "Schema applied"
+
+step "Uploading status.config.yml to KV"
+bun run --filter '@status-please/worker' kv:config
+ok "Config uploaded"
+
+step "Deploying the check Worker + status page"
+bun run deploy
+ok "Deployed"
+
+# --- next steps ------------------------------------------------------------
+printf '\n%s✓ status-please is live.%s\n' "$GRN$B" "$RST"
+cat <<EOF
+${DIM}
+Next:
+  • The cron runs every few minutes — the page shows sample data until the
+    first check writes a real snapshot. Force one now from the Cloudflare
+    dashboard → Workers → status-please-worker → Cron Triggers → Trigger.
+  • Instant cache purge (optional): set the two secrets on the check Worker
+      bunx wrangler secret put CF_API_TOKEN --config apps/worker/wrangler.jsonc
+      bunx wrangler secret put CF_ZONE_ID   --config apps/worker/wrangler.jsonc
+  • Re-run 'bun run setup' any time to change the domain, cron, or redeploy.
+  • Commit the updated wrangler.jsonc + status.config.yml to your fork.
+Full runbook: DEPLOYMENT.md${RST}
+EOF

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -24,5 +24,6 @@ sonar.cpd.exclusions=packages/core/src/i18n.ts
 # The coverage gate applies to the domain logic in packages/ (unit-tested).
 # The apps (Astro UI islands + Cloudflare Worker runtime glue) are validated by
 # build + integration/e2e, not unit coverage — so they are excluded here.
-# Also exclude vendored shadcn/ui components and framework config/type files.
-sonar.coverage.exclusions=**/*.test.*,**/*.spec.*,**/*.config.*,**/env.d.ts,apps/**,**/components/ui/**
+# Also exclude vendored shadcn/ui components and framework config/type files,
+# and the setup/deploy scripts (validated by direct execution, not unit tests).
+sonar.coverage.exclusions=**/*.test.*,**/*.spec.*,**/*.config.*,**/env.d.ts,apps/**,**/components/ui/**,scripts/**


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

Adds a Cloudflare deploy story for forks: a static "Deploy on Cloudflare" badge in the
README plus a guided `bun run setup` script.

A one-click "Deploy to Cloudflare" button was **deliberately not used** — it can't deploy
this monorepo. This repo has two Workers (`apps/worker` + `apps/web`) sharing the
`packages/core` workspace package, and Cloudflare's Deploy button is one-Worker-per-button
and requires self-contained subdirectories. `bun run setup` is the guided equivalent: it
provisions D1 + KV idempotently, interactively prompts for wrangler settings (custom
domain, cron schedule) and the status page name, seeds `status.config.yml`, applies the D1
schema, uploads config to KV, and deploys both Workers by reusing the existing `bun run`
tasks.

## Changes

- `README.md`: static "Deploy on Cloudflare" shields.io badge (links to `DEPLOYMENT.md`,
  not a one-click button), plus a "Fastest path — the guided script" block in the
  Deployment section; manual steps folded into a `<details>`.
- `DEPLOYMENT.md`: "Quick start (scripted)" section at the top documenting `bun run setup`;
  the rest of the doc is now framed as the manual path.
- `package.json`: `"setup": "bash scripts/setup.sh"` root script.
- `scripts/setup.sh` (new): interactive one-shot setup+deploy for a fork.
- `scripts/apply-config.ts` (new): writes account-specific settings into both
  `wrangler.jsonc` files idempotently without disturbing their JSONC comments.

## Test Plan

- [x] Verified locally: custom-domain and workers.dev branches, idempotent re-runs, JSONC
      validity after edits, cron/resource-ID injection, bash syntax (`bash -n`), `--help`
- [ ] **Not executed**: the live Cloudflare provisioning/deploy path (it creates real
      account resources). A first real run should confirm the `wrangler d1 list --json` /
      `wrangler kv namespace list --json` output field names against the installed
      wrangler version, since the parsing in `apply-config.ts` depends on them.

## Related issue

N/A

## Checklist

- [x] PR title follows Conventional Commits
- [ ] Tests added or updated, and the suite passes (`bun run test`) — n/a, docs + shell/bun script, no test suite coverage for this script
- [x] Lint/format pass (`bun run lint`)
- [x] Documentation updated if behavior changed
- [x] No breaking change, or a `BREAKING CHANGE:` note is included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guided Cloudflare setup and deploy via `bun run setup`, plus docs and a static "Deploy on Cloudflare" badge. Hardens the flow with fail-fast config edits (networking and cron) and stricter D1/KV lookups that treat CLI failures or malformed `--json` output as errors, plus YAML‑safe prompts.

- **New Features**
  - `scripts/setup.sh` (run with `bun run setup`): provisions D1 + KV idempotently, prompts for custom domain, cron, and page name, seeds `status.config.yml`, applies schema, uploads config to KV, and deploys both Workers. Flags: `--yes`, `--skip-deploy`, `--help`. Uses workspace-local `wrangler` via `bunx`, runs `bun install --ignore-scripts`, handles closed stdin, accepts a bare `--`, quotes the page name via `JSON.stringify`, and aborts when `wrangler` calls fail or return malformed `--json` output (not misread as “not found”).
  - `scripts/apply-config.ts`: injects D1/KV IDs; rewrites the web app networking block with managed markers; updates the check Worker cron. Throws when networking or cron can’t be placed; uses replacer functions to avoid `$`-pattern issues.
  - Docs: `README.md` adds a static "Deploy on Cloudflare" badge and quick start; `DEPLOYMENT.md` adds "Quick start (scripted)"; `package.json` adds `"setup": "bash scripts/setup.sh"`; `sonar-project.properties` excludes `scripts/**` from coverage.

- **Migration**
  - Run `bunx wrangler login`, then `bun install` and `bun run setup` (`--skip-deploy` to configure only).
  - Commit the updated `wrangler.jsonc` files and `status.config.yml`.

<sup>Written for commit 6cb818ad9a36c7e9a06d4c3202c0e6c0d8c7b9e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided setup command that helps provision required Cloudflare resources, configure the app, and deploy in one flow.
  * Supports interactive prompts or a non-interactive mode, with an option to skip deployment.

* **Documentation**
  * Expanded the README and deployment guide with a faster setup path, prerequisites, login options, and manual setup alternatives.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->