### PR TITLE
feat(core): add Atlassian Statuspage check adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,22 @@ theme:
   locale: en # fallback UI language: en | zh | ja | ko (default en)
 ```
 
+### Check types
+
+Each site sets a `check` kind:
+
+| `check`      | What it does                                                                 |
+| ------------ | --------------------------------------------------------------------------- |
+| `http`       | Fetches `url`; `up`/`degraded`/`down` from the status code and response time.|
+| `tcp`        | Reserved — currently falls through to `http` ([roadmap](#roadmap)).          |
+| `ssl`        | Reserved — currently falls through to `http` ([roadmap](#roadmap)).          |
+| `statuspage` | Mirrors an Atlassian Statuspage's own verdict. See the [Statuspage adapter guide](./docs/adapters/statuspage.md).|
+
+The **Statuspage adapter** reads a vendor's `/api/v2/summary.json` (Claude,
+Vercel, `*.statuspage.io`, …) and maps their overall indicator — or a single
+component you name — to a status. Full reference, status-mapping tables, and
+edge behavior: [`docs/adapters/statuspage.md`](./docs/adapters/statuspage.md).
+
 ### Internationalization
 
 The status page UI is translated into English (`en`), Simplified Chinese (`zh`),
@@ -301,6 +317,7 @@ deploy — is in **[DEPLOYMENT.md](./DEPLOYMENT.md)**.
 - [x] **Notify layer (part 1)** — Slack + generic webhook on status change, decoupled via Queues.
 - [x] **Edge cache** — `Cache-Tag` emit + purge-on-change loop between the check and display layers.
 - [x] **Badges & public API** — [shields.io endpoint](#badges--public-api) badges + JSON status API, edge-cached.
+- [x] **Statuspage adapter** — mirror any Atlassian Statuspage by page or component ([guide](./docs/adapters/statuspage.md)).
 
 **In progress / planned**
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ sites:
   - name: API
     url: https://api.example.com/health
     check: http
+  - name: Claude # mirror an Atlassian Statuspage (status.claude.com, *.statuspage.io, …)
+    url: https://status.claude.com # base URL; /api/v2/summary.json is appended for you
+    check: statuspage
+  - name: Claude API # or track one service on that page by component name/id
+    url: https://status.claude.com
+    check: statuspage
+    component: Claude API (api.anthropic.com)
 notifications: # all optional; keep the real Slack URL (a secret) in your KV config
   slack:
     webhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ name: Acme Status
 sites:
   - name: Website
     url: https://example.com
-    check: http # http | tcp | ssl
+    check: http # http | tcp | ssl | statuspage
     expectedStatusCodes: [200]
     maxResponseTime: 2000 # ms → "degraded" above this
   - name: API

--- a/docs/adapters/statuspage.md
+++ b/docs/adapters/statuspage.md
@@ -111,18 +111,22 @@ something is off without ever silently reporting `up`.
 Every outcome below produces a normal `CheckResult`, so it flows into the D1
 time-series, KV snapshot, badges, and notifications like any other check.
 
-| Situation                                   | `status` | `code`       | `error`                                        |
-| ------------------------------------------- | -------- | ------------ | ---------------------------------------------- |
-| Component/page reads healthy                | `up`     | `200`        | —                                              |
-| Component/page reads degraded/down          | mapped   | `200`        | —                                              |
-| `component` not found on the page           | `down`   | `200`        | `Statuspage component not found: <name>`       |
-| API returns non-2xx                         | `down`   | actual (e.g. `503`) | `Statuspage API returned 503`           |
-| Body isn't a JSON object (e.g. `null`, HTML)| `down`   | `200`        | `Statuspage summary.json was not a JSON object` / parse error |
-| Request never completes (DNS/TLS/timeout)   | `down`   | `0`          | the thrown error message                       |
+| Situation                                   | `status` | `code`              | `error`                                        |
+| ------------------------------------------- | -------- | ------------------- | ---------------------------------------------- |
+| Component/page reads healthy                | `up`     | 2xx (normally `200`)| —                                              |
+| Component/page reads degraded/down          | mapped   | 2xx (normally `200`)| —                                              |
+| `component` not found on the page           | `down`   | 2xx (normally `200`)| `Statuspage component not found: <name>`       |
+| API returns non-2xx                         | `down`   | actual (e.g. `503`) | `Statuspage API returned 503`                  |
+| Body isn't a JSON object (e.g. `null`, HTML)| `down`   | 2xx (normally `200`)| `Statuspage summary.json was not a JSON object` / parse error |
+| Request never completes (DNS/TLS/timeout)   | `down`   | `0`                 | the thrown error message                       |
+
+The `code` column holds the response's real HTTP status (`res.status`); it is
+`200` for a normal healthy page but reflects whatever 2xx the API actually
+returned.
 
 The key distinction: `code` reflects **whether the HTTP request completed**.
-A misconfigured `component` (a typo) fails _after_ a successful `200` response,
-so it records `code: 200` — deterministic and repeatable on every cron run —
+A misconfigured `component` (a typo) fails _after_ a successful response, so it
+records the real 2xx code — deterministic and repeatable on every cron run —
 whereas a genuine network outage records `code: 0`. This keeps a persistent
 config mistake from masquerading as transient flakiness in your history.
 

--- a/docs/adapters/statuspage.md
+++ b/docs/adapters/statuspage.md
@@ -1,0 +1,156 @@
+# Statuspage adapter
+
+Mirror status straight from any **Atlassian Statuspage** — `status.claude.com`,
+`www.vercel-status.com`, `*.statuspage.io`, and the thousands of vendor pages
+built on Statuspage — instead of probing an endpoint yourself.
+
+A regular `http` check tells you whether _your_ request succeeded. The
+`statuspage` check instead reads the vendor's own published verdict: one request
+to their `/api/v2/summary.json` returns the overall page indicator plus every
+component, and status-please maps that to its `up` / `degraded` / `down` model.
+
+## When to use it
+
+- You depend on a third-party service (Claude, Vercel, GitHub, Stripe, …) that
+  publishes an Atlassian Statuspage, and you want _their_ assessment of an
+  incident rather than a naive reachability ping.
+- You want per-service granularity — e.g. track only "Claude API
+  (api.anthropic.com)" from a page that also lists the web app, Console, and
+  other components.
+
+For a service you operate yourself, a plain [`http`](../../README.md#configuration)
+check is usually the better fit.
+
+## Configuration
+
+```yaml
+sites:
+  # Whole page: grade by the page's overall indicator.
+  - name: Claude
+    url: https://status.claude.com
+    check: statuspage
+
+  # Single component: grade by one service on the page.
+  - name: Claude API
+    url: https://status.claude.com
+    check: statuspage
+    component: Claude API (api.anthropic.com)
+```
+
+| Field       | Required | Meaning                                                                                                     |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `check`     | yes      | Must be `statuspage`.                                                                                       |
+| `url`       | yes      | The Statuspage **base URL**. `/api/v2/summary.json` is appended automatically (see [URL derivation](#url-derivation)). |
+| `component` | no       | Track a single component instead of the whole page. Matched by **name** (case-insensitive) or **id**. When omitted, the page's overall indicator is used. |
+| `name`      | yes      | Display name on your status page (as with any site).                                                       |
+
+`expectedStatusCodes` and `maxResponseTime` are ignored for `statuspage` checks —
+the verdict comes entirely from the payload, not from the HTTP code or latency of
+the API call (see [Notes](#notes--limitations)).
+
+### URL derivation
+
+`url` is normally the page's base URL and status-please builds the API endpoint
+for you:
+
+| Configured `url`                              | Requested endpoint                                        |
+| --------------------------------------------- | --------------------------------------------------------- |
+| `https://status.claude.com`                   | `https://status.claude.com/api/v2/summary.json`           |
+| `https://www.vercel-status.com/` (trailing /) | `https://www.vercel-status.com/api/v2/summary.json`       |
+| `https://status.claude.com/api/v2/status.json`| used verbatim (already an `/api/v2/*.json` endpoint)       |
+
+The last row is an escape hatch: if you point `url` directly at an `/api/v2/*.json`
+endpoint, it is used as-is. In practice you should keep `url` as the base URL and
+let the adapter target `summary.json`, because only `summary.json` carries the
+component list that `component` matching needs.
+
+## Finding a component name or id
+
+Open the page's component list and copy the exact `name` (or the stable `id`):
+
+```bash
+curl -s https://status.claude.com/api/v2/components.json \
+  | jq -r '.components[] | "\(.id)  \(.status)  \(.name)"'
+```
+
+Use either value for `component:`. Name matching is case-insensitive and trims
+surrounding whitespace; id matching is exact. If your service name contains YAML
+special characters, quote it: `component: "Claude API (api.anthropic.com)"`.
+
+## Status mapping
+
+status-please has three states — `up`, `degraded`, `down`. Statuspage's richer
+vocabulary is folded in as follows.
+
+**Overall page indicator** (used when no `component` is set):
+
+| Statuspage `status.indicator` | status-please |
+| ----------------------------- | ------------- |
+| `none`                        | `up`          |
+| `minor`                       | `degraded`    |
+| `major`                       | `down`        |
+| `critical`                    | `down`        |
+| `maintenance`                 | `degraded`    |
+
+**Component status** (used when `component` matches one service):
+
+| Statuspage component `status` | status-please |
+| ----------------------------- | ------------- |
+| `operational`                 | `up`          |
+| `degraded_performance`        | `degraded`    |
+| `partial_outage`              | `degraded`    |
+| `major_outage`                | `down`        |
+| `under_maintenance`           | `degraded`    |
+
+Any **unrecognized** status/indicator string (a future Atlassian value, a
+renamed state) maps to `degraded` — a deliberate, safe default: it surfaces that
+something is off without ever silently reporting `up`.
+
+## Failure & edge behavior
+
+Every outcome below produces a normal `CheckResult`, so it flows into the D1
+time-series, KV snapshot, badges, and notifications like any other check.
+
+| Situation                                   | `status` | `code`       | `error`                                        |
+| ------------------------------------------- | -------- | ------------ | ---------------------------------------------- |
+| Component/page reads healthy                | `up`     | `200`        | —                                              |
+| Component/page reads degraded/down          | mapped   | `200`        | —                                              |
+| `component` not found on the page           | `down`   | `200`        | `Statuspage component not found: <name>`       |
+| API returns non-2xx                         | `down`   | actual (e.g. `503`) | `Statuspage API returned 503`           |
+| Body isn't a JSON object (e.g. `null`, HTML)| `down`   | `200`        | `Statuspage summary.json was not a JSON object` / parse error |
+| Request never completes (DNS/TLS/timeout)   | `down`   | `0`          | the thrown error message                       |
+
+The key distinction: `code` reflects **whether the HTTP request completed**.
+A misconfigured `component` (a typo) fails _after_ a successful `200` response,
+so it records `code: 200` — deterministic and repeatable on every cron run —
+whereas a genuine network outage records `code: 0`. This keeps a persistent
+config mistake from masquerading as transient flakiness in your history.
+
+> **Tip:** if a `statuspage` site shows `down` with `code: 200` and a
+> "component not found" error, it's almost always a typo in `component:` — check
+> the exact name via `components.json` above.
+
+## Notes & limitations
+
+- **Latency is not graded.** `responseTime` is recorded (it measures the
+  `summary.json` call), but a slow status-page API doesn't mean the monitored
+  service is slow, so it never affects the verdict. Contrast with `http` checks,
+  where `maxResponseTime` marks a site `degraded`.
+- **One component per site entry.** To track several components from the same
+  page, add one `site` entry per component (they share the same `url`).
+- **Incidents aren't ingested yet.** Only the current status is read. The
+  vendor's incident history and scheduled maintenances in `summary.json` are not
+  imported into status-please's own incident timeline.
+- **Trusted config.** `url` comes from your committed `status.config.yml`, not
+  from end users; it's validated as a URL at parse time.
+
+## How it fits together
+
+The adapter lives in [`packages/core/src/check.ts`](../../packages/core/src/check.ts):
+`checkSite` dispatches on `site.check`, and `checkStatuspage` handles the fetch,
+shape-guarding, and grading via `deriveStatuspageStatus`. The config schema
+(`checkKindSchema`, the optional `component` field) is in
+[`packages/core/src/config.ts`](../../packages/core/src/config.ts). The Cron
+Worker calls `checkSite` for every configured site — no adapter-specific wiring
+is needed downstream, because the adapter returns the same `CheckResult` shape as
+every other check.

--- a/docs/adapters/statuspage.md
+++ b/docs/adapters/statuspage.md
@@ -41,7 +41,7 @@ sites:
 | ----------- | -------- | ---------------------------------------------------------------------------------------------------------- |
 | `check`     | yes      | Must be `statuspage`.                                                                                       |
 | `url`       | yes      | The Statuspage **base URL**. `/api/v2/summary.json` is appended automatically (see [URL derivation](#url-derivation)). |
-| `component` | no       | Track a single component instead of the whole page. Matched by **name** (case-insensitive) or **id**. When omitted, the page's overall indicator is used. |
+| `component` | no       | Track a single component instead of the whole page. Matched by **name** (case-insensitive) or **id**. When omitted, the page's overall indicator is used. Only valid with `check: statuspage` — setting it on another check kind is a parse error (guards against a mistyped `check`). |
 | `name`      | yes      | Display name on your status page (as with any site).                                                       |
 
 `expectedStatusCodes` and `maxResponseTime` are ignored for `statuspage` checks —

--- a/packages/core/src/check.test.ts
+++ b/packages/core/src/check.test.ts
@@ -174,7 +174,19 @@ describe('checkSite (statuspage)', () => {
     })
     expect(result.status).toBe('down')
     expect(result.code).toBe(200)
-    expect(result.error).toMatch(/not a JSON object/)
+    expect(result.error).toMatch(/failed validation/)
+  })
+
+  it('reports down when the body has the wrong shape', async () => {
+    // Valid JSON, but `status` is a string where an object is expected — the
+    // schema rejects it instead of grading a malformed payload.
+    const result = await checkSite(pageSite, {
+      fetchImpl: statuspageResponse({ status: 'oops', components: 'nope' }),
+      now: () => 0,
+    })
+    expect(result.status).toBe('down')
+    expect(result.code).toBe(200)
+    expect(result.error).toMatch(/failed validation/)
   })
 
   it('fetches the derived summary.json endpoint', async () => {

--- a/packages/core/src/check.test.ts
+++ b/packages/core/src/check.test.ts
@@ -75,10 +75,21 @@ describe('statuspageSummaryUrl', () => {
 })
 
 describe('deriveStatuspageStatus', () => {
-  it('maps the overall indicator when no component is given', () => {
+  it('maps every overall indicator when no component is given', () => {
     expect(deriveStatuspageStatus({ status: { indicator: 'none' } })).toBe('up')
     expect(deriveStatuspageStatus({ status: { indicator: 'minor' } })).toBe('degraded')
+    expect(deriveStatuspageStatus({ status: { indicator: 'major' } })).toBe('down')
     expect(deriveStatuspageStatus({ status: { indicator: 'critical' } })).toBe('down')
+    expect(deriveStatuspageStatus({ status: { indicator: 'maintenance' } })).toBe('degraded')
+  })
+
+  it('maps every component status', () => {
+    const status = (s: string) => deriveStatuspageStatus({ components: [{ name: 'X', status: s }] }, 'X')
+    expect(status('operational')).toBe('up')
+    expect(status('degraded_performance')).toBe('degraded')
+    expect(status('partial_outage')).toBe('degraded')
+    expect(status('major_outage')).toBe('down')
+    expect(status('under_maintenance')).toBe('degraded')
   })
 
   it('reads a specific component by case-insensitive name', () => {
@@ -119,7 +130,46 @@ describe('checkSite (statuspage)', () => {
   it('grades a single configured component', async () => {
     const result = await checkSite(componentSite, { fetchImpl: statuspageResponse(claudeSummary), now: () => 0 })
     expect(result.status).toBe('down')
+    expect(result.code).toBe(200)
     expect(result.slug).toBe('claude-api')
+  })
+
+  it('reports down when a configured component is not on the page', async () => {
+    const missing = siteSchema.parse({
+      name: 'Claude API',
+      url: 'https://status.claude.com',
+      check: 'statuspage',
+      component: 'Nonexistent Service',
+    })
+    const result = await checkSite(missing, { fetchImpl: statuspageResponse(claudeSummary), now: () => 0 })
+    expect(result.status).toBe('down')
+    expect(result.error).toMatch(/not found/)
+    // The fetch completed (200) — a config typo must not masquerade as a
+    // network failure (code 0) in the persisted history.
+    expect(result.code).toBe(200)
+  })
+
+  it('reports down with the real status code on a non-JSON body', async () => {
+    const result = await checkSite(pageSite, {
+      fetchImpl: () => Promise.resolve(new Response('<html>not json</html>', { status: 200 })),
+      now: () => 0,
+    })
+    expect(result.status).toBe('down')
+    expect(result.code).toBe(200)
+    expect(result.error).toBeDefined()
+  })
+
+  it('reports down on a JSON null body instead of throwing', async () => {
+    const result = await checkSite(pageSite, {
+      fetchImpl: () => Promise.resolve(new Response('null', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })),
+      now: () => 0,
+    })
+    expect(result.status).toBe('down')
+    expect(result.code).toBe(200)
+    expect(result.error).toMatch(/not a JSON object/)
   })
 
   it('fetches the derived summary.json endpoint', async () => {

--- a/packages/core/src/check.test.ts
+++ b/packages/core/src/check.test.ts
@@ -77,6 +77,11 @@ describe('statuspageSummaryUrl', () => {
     const url = 'https://status.claude.com/api/v2/status.json'
     expect(statuspageSummaryUrl(url)).toBe(url)
   })
+
+  it('leaves an explicit api/v2 endpoint untouched even with trailing slashes', () => {
+    expect(statuspageSummaryUrl('https://status.claude.com/api/v2/status.json///'))
+      .toBe('https://status.claude.com/api/v2/status.json')
+  })
 })
 
 describe('deriveStatuspageStatus', () => {
@@ -104,6 +109,11 @@ describe('deriveStatuspageStatus', () => {
 
   it('reads a specific component by id', () => {
     expect(deriveStatuspageStatus(claudeSummary, 'abc')).toBe('down')
+  })
+
+  it('trims surrounding whitespace before matching id or name', () => {
+    expect(deriveStatuspageStatus(claudeSummary, '  abc  ')).toBe('down')
+    expect(deriveStatuspageStatus(claudeSummary, '  claude.ai  ')).toBe('degraded')
   })
 
   it('throws when a named component is missing', () => {

--- a/packages/core/src/check.test.ts
+++ b/packages/core/src/check.test.ts
@@ -1,8 +1,24 @@
 import { describe, expect, it } from 'bun:test'
-import { checkSite, deriveStatus } from './check'
+import { checkSite, deriveStatus, deriveStatuspageStatus, statuspageSummaryUrl } from './check'
 import { siteSchema } from './config'
 
 const site = siteSchema.parse({ name: 'Example', url: 'https://example.com' })
+
+/** A minimal Statuspage summary.json body for the given indicator/components. */
+function statuspageResponse(body: unknown): () => Promise<Response> {
+  return () => Promise.resolve(new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  }))
+}
+
+const claudeSummary = {
+  status: { indicator: 'none', description: 'All Systems Operational' },
+  components: [
+    { id: 'abc', name: 'Claude API (api.anthropic.com)', status: 'major_outage' },
+    { id: 'def', name: 'claude.ai', status: 'degraded_performance' },
+  ],
+}
 
 describe('deriveStatus', () => {
   it('is up for an expected, fast response', () => {
@@ -38,5 +54,103 @@ describe('checkSite', () => {
     expect(result.status).toBe('up')
     expect(result.code).toBe(200)
     expect(result.slug).toBe('example')
+  })
+})
+
+describe('statuspageSummaryUrl', () => {
+  it('appends the API path to a bare page URL', () => {
+    expect(statuspageSummaryUrl('https://status.claude.com'))
+      .toBe('https://status.claude.com/api/v2/summary.json')
+  })
+
+  it('strips a trailing slash before appending', () => {
+    expect(statuspageSummaryUrl('https://www.vercel-status.com/'))
+      .toBe('https://www.vercel-status.com/api/v2/summary.json')
+  })
+
+  it('leaves an explicit api/v2 endpoint untouched', () => {
+    const url = 'https://status.claude.com/api/v2/status.json'
+    expect(statuspageSummaryUrl(url)).toBe(url)
+  })
+})
+
+describe('deriveStatuspageStatus', () => {
+  it('maps the overall indicator when no component is given', () => {
+    expect(deriveStatuspageStatus({ status: { indicator: 'none' } })).toBe('up')
+    expect(deriveStatuspageStatus({ status: { indicator: 'minor' } })).toBe('degraded')
+    expect(deriveStatuspageStatus({ status: { indicator: 'critical' } })).toBe('down')
+  })
+
+  it('reads a specific component by case-insensitive name', () => {
+    expect(deriveStatuspageStatus(claudeSummary, 'claude api (api.anthropic.com)')).toBe('down')
+    expect(deriveStatuspageStatus(claudeSummary, 'claude.ai')).toBe('degraded')
+  })
+
+  it('reads a specific component by id', () => {
+    expect(deriveStatuspageStatus(claudeSummary, 'abc')).toBe('down')
+  })
+
+  it('throws when a named component is missing', () => {
+    expect(() => deriveStatuspageStatus(claudeSummary, 'nonexistent')).toThrow(/not found/)
+  })
+
+  it('falls back to degraded for unknown status strings', () => {
+    expect(deriveStatuspageStatus({ status: { indicator: 'weird' } })).toBe('degraded')
+    expect(deriveStatuspageStatus({ components: [{ name: 'X', status: 'weird' }] }, 'X')).toBe('degraded')
+  })
+})
+
+describe('checkSite (statuspage)', () => {
+  const pageSite = siteSchema.parse({ name: 'Claude', url: 'https://status.claude.com', check: 'statuspage' })
+  const componentSite = siteSchema.parse({
+    name: 'Claude API',
+    url: 'https://status.claude.com',
+    check: 'statuspage',
+    component: 'Claude API (api.anthropic.com)',
+  })
+
+  it('grades the overall page indicator', async () => {
+    const result = await checkSite(pageSite, { fetchImpl: statuspageResponse(claudeSummary), now: () => 0 })
+    expect(result.status).toBe('up')
+    expect(result.code).toBe(200)
+    expect(result.slug).toBe('claude')
+  })
+
+  it('grades a single configured component', async () => {
+    const result = await checkSite(componentSite, { fetchImpl: statuspageResponse(claudeSummary), now: () => 0 })
+    expect(result.status).toBe('down')
+    expect(result.slug).toBe('claude-api')
+  })
+
+  it('fetches the derived summary.json endpoint', async () => {
+    let requested = ''
+    await checkSite(pageSite, {
+      fetchImpl: (url) => {
+        requested = url
+        return statuspageResponse(claudeSummary)()
+      },
+      now: () => 0,
+    })
+    expect(requested).toBe('https://status.claude.com/api/v2/summary.json')
+  })
+
+  it('reports down on a non-2xx API response', async () => {
+    const result = await checkSite(pageSite, {
+      fetchImpl: () => Promise.resolve(new Response('nope', { status: 503 })),
+      now: () => 0,
+    })
+    expect(result.status).toBe('down')
+    expect(result.code).toBe(503)
+    expect(result.error).toContain('503')
+  })
+
+  it('reports down when the fetch throws', async () => {
+    const result = await checkSite(pageSite, {
+      fetchImpl: () => Promise.reject(new Error('network')),
+      now: () => 0,
+    })
+    expect(result.status).toBe('down')
+    expect(result.code).toBe(0)
+    expect(result.error).toBe('network')
   })
 })

--- a/packages/core/src/check.test.ts
+++ b/packages/core/src/check.test.ts
@@ -68,6 +68,11 @@ describe('statuspageSummaryUrl', () => {
       .toBe('https://www.vercel-status.com/api/v2/summary.json')
   })
 
+  it('strips multiple trailing slashes', () => {
+    expect(statuspageSummaryUrl('https://status.claude.com///'))
+      .toBe('https://status.claude.com/api/v2/summary.json')
+  })
+
   it('leaves an explicit api/v2 endpoint untouched', () => {
     const url = 'https://status.claude.com/api/v2/status.json'
     expect(statuspageSummaryUrl(url)).toBe(url)

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -27,8 +27,9 @@ export function deriveStatus(
  * Run one check for a site. Injectable `fetchImpl` and `now` keep this pure and
  * testable; the Worker passes the platform `fetch`.
  *
- * Only HTTP checks are implemented here; `tcp`/`ssl` are handled by the Worker
- * runtime and tracked in the roadmap.
+ * Dispatches on `site.check`: `statuspage` reads an Atlassian Statuspage JSON
+ * API; every other kind (`http`/`tcp`/`ssl`) currently falls through to a plain
+ * HTTP fetch. `tcp`/`ssl` runtime probing is tracked in the roadmap.
  */
 export async function checkSite(
   site: Site,
@@ -36,6 +37,14 @@ export async function checkSite(
 ): Promise<CheckResult> {
   const fetchImpl = deps.fetchImpl ?? fetch
   const now = deps.now ?? Date.now
+  if (site.check === 'statuspage') {
+    return checkStatuspage(site, fetchImpl, now)
+  }
+  return checkHttp(site, fetchImpl, now)
+}
+
+/** Plain HTTP check: fetch the URL and grade by status code and latency. */
+async function checkHttp(site: Site, fetchImpl: FetchLike, now: () => number): Promise<CheckResult> {
   const start = now()
 
   try {
@@ -47,6 +56,107 @@ export async function checkSite(
     return {
       slug: site.slug,
       status: deriveStatus(res.status, responseTime, site),
+      code: res.status,
+      responseTime,
+      checkedAt: new Date(start).toISOString(),
+    }
+  }
+  catch (err) {
+    return {
+      slug: site.slug,
+      status: 'down',
+      code: 0,
+      responseTime: now() - start,
+      checkedAt: new Date(start).toISOString(),
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+/** Atlassian Statuspage component `status` → our {@link CheckStatus}. */
+const STATUSPAGE_COMPONENT_STATUS: Record<string, CheckStatus> = {
+  operational: 'up',
+  degraded_performance: 'degraded',
+  partial_outage: 'degraded',
+  major_outage: 'down',
+  under_maintenance: 'degraded',
+}
+
+/** Atlassian Statuspage overall page `indicator` → our {@link CheckStatus}. */
+const STATUSPAGE_INDICATOR_STATUS: Record<string, CheckStatus> = {
+  none: 'up',
+  minor: 'degraded',
+  major: 'down',
+  critical: 'down',
+  maintenance: 'degraded',
+}
+
+/** The slice of an Atlassian Statuspage `summary.json` payload we rely on. */
+export interface StatuspageSummary {
+  status?: { indicator?: string, description?: string }
+  components?: Array<{ id?: string, name?: string, status?: string }>
+}
+
+/**
+ * Resolve the `summary.json` API URL for a configured Statuspage `url`. A bare
+ * page URL (`https://status.claude.com`) gets `/api/v2/summary.json` appended;
+ * a URL already pointing at an `/api/v2/*.json` endpoint is used verbatim.
+ */
+export function statuspageSummaryUrl(url: string): string {
+  if (/\/api\/v2\/[^/]+\.json$/.test(url)) {
+    return url
+  }
+  return `${url.replace(/\/+$/, '')}/api/v2/summary.json`
+}
+
+/**
+ * Grade a Statuspage `summary.json` payload. With a `component` (matched by id
+ * or case-insensitive name) the single component's status wins; otherwise the
+ * page's overall `indicator` is used. Unknown status strings map to `degraded`
+ * (something is off, but not clearly an outage). Throws when a named component
+ * isn't present so the caller records it as `down` with a clear error.
+ */
+export function deriveStatuspageStatus(summary: StatuspageSummary, component?: string): CheckStatus {
+  if (component !== undefined) {
+    const target = component.trim().toLowerCase()
+    const match = summary.components?.find(
+      c => c.id === component || c.name?.trim().toLowerCase() === target,
+    )
+    if (!match) {
+      throw new Error(`Statuspage component not found: ${component}`)
+    }
+    return STATUSPAGE_COMPONENT_STATUS[match.status ?? ''] ?? 'degraded'
+  }
+  return STATUSPAGE_INDICATOR_STATUS[summary.status?.indicator ?? ''] ?? 'degraded'
+}
+
+/**
+ * Statuspage check: fetch the page's `summary.json` and map the overall
+ * indicator (or a single configured `component`) to a {@link CheckStatus}.
+ * `responseTime` measures the API call, not the monitored service, so it does
+ * not affect the verdict — the status comes entirely from the payload.
+ */
+async function checkStatuspage(site: Site, fetchImpl: FetchLike, now: () => number): Promise<CheckResult> {
+  const start = now()
+  const url = statuspageSummaryUrl(site.url)
+
+  try {
+    const res = await fetchImpl(url, { method: 'GET', redirect: 'follow' })
+    const responseTime = now() - start
+    if (!res.ok) {
+      return {
+        slug: site.slug,
+        status: 'down',
+        code: res.status,
+        responseTime,
+        checkedAt: new Date(start).toISOString(),
+        error: `Statuspage API returned ${res.status}`,
+      }
+    }
+    const summary = (await res.json()) as StatuspageSummary
+    return {
+      slug: site.slug,
+      status: deriveStatuspageStatus(summary, site.component),
       code: res.status,
       responseTime,
       checkedAt: new Date(start).toISOString(),

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -124,17 +124,21 @@ export type StatuspageSummary = z.infer<typeof statuspageSummarySchema>
  * a URL already pointing at an `/api/v2/*.json` endpoint is used verbatim.
  */
 export function statuspageSummaryUrl(url: string): string {
-  if (/\/api\/v2\/[^/]+\.json$/.test(url)) {
-    return url
-  }
-  // Strip trailing slashes with a linear character scan rather than a
+  // Strip trailing slashes first, with a linear character scan rather than a
   // backtracking regex (`/\/+$/` is a polynomial-ReDoS pattern on inputs with
-  // many trailing slashes — flagged by CodeQL js/polynomial-redos).
+  // many trailing slashes — flagged by CodeQL js/polynomial-redos). Testing the
+  // cleaned URL against the endpoint pattern also handles an explicit
+  // `/api/v2/*.json` URL that carries a trailing slash (otherwise the guard
+  // would miss it and produce a doubled `.../summary.json/api/v2/summary.json`).
   let end = url.length
   while (end > 0 && url.charCodeAt(end - 1) === 47 /* '/' */) {
     end--
   }
-  return `${url.slice(0, end)}/api/v2/summary.json`
+  const cleaned = url.slice(0, end)
+  if (/\/api\/v2\/[^/]+\.json$/.test(cleaned)) {
+    return cleaned
+  }
+  return `${cleaned}/api/v2/summary.json`
 }
 
 /**
@@ -146,9 +150,10 @@ export function statuspageSummaryUrl(url: string): string {
  */
 export function deriveStatuspageStatus(summary: StatuspageSummary, component?: string): CheckStatus {
   if (component !== undefined) {
-    const target = component.trim().toLowerCase()
+    const trimmed = component.trim()
+    const target = trimmed.toLowerCase()
     const match = summary.components?.find(
-      c => c.id === component || c.name?.trim().toLowerCase() === target,
+      c => c.id === trimmed || c.name?.trim().toLowerCase() === target,
     )
     if (!match) {
       throw new Error(`Statuspage component not found: ${component}`)

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -106,7 +106,14 @@ export function statuspageSummaryUrl(url: string): string {
   if (/\/api\/v2\/[^/]+\.json$/.test(url)) {
     return url
   }
-  return `${url.replace(/\/+$/, '')}/api/v2/summary.json`
+  // Strip trailing slashes with a linear character scan rather than a
+  // backtracking regex (`/\/+$/` is a polynomial-ReDoS pattern on inputs with
+  // many trailing slashes — flagged by CodeQL js/polynomial-redos).
+  let end = url.length
+  while (end > 0 && url.charCodeAt(end - 1) === 47 /* '/' */) {
+    end--
+  }
+  return `${url.slice(0, end)}/api/v2/summary.json`
 }
 
 /**

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -139,28 +139,13 @@ export function deriveStatuspageStatus(summary: StatuspageSummary, component?: s
 async function checkStatuspage(site: Site, fetchImpl: FetchLike, now: () => number): Promise<CheckResult> {
   const start = now()
   const url = statuspageSummaryUrl(site.url)
+  const checkedAt = new Date(start).toISOString()
 
+  // Phase 1: the network round-trip. A throw here means the request never
+  // completed, so `code: 0` is the honest signal (per CheckResult.code).
+  let res: Response
   try {
-    const res = await fetchImpl(url, { method: 'GET', redirect: 'follow' })
-    const responseTime = now() - start
-    if (!res.ok) {
-      return {
-        slug: site.slug,
-        status: 'down',
-        code: res.status,
-        responseTime,
-        checkedAt: new Date(start).toISOString(),
-        error: `Statuspage API returned ${res.status}`,
-      }
-    }
-    const summary = (await res.json()) as StatuspageSummary
-    return {
-      slug: site.slug,
-      status: deriveStatuspageStatus(summary, site.component),
-      code: res.status,
-      responseTime,
-      checkedAt: new Date(start).toISOString(),
-    }
+    res = await fetchImpl(url, { method: 'GET', redirect: 'follow' })
   }
   catch (err) {
     return {
@@ -168,7 +153,41 @@ async function checkStatuspage(site: Site, fetchImpl: FetchLike, now: () => numb
       status: 'down',
       code: 0,
       responseTime: now() - start,
-      checkedAt: new Date(start).toISOString(),
+      checkedAt,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+
+  const responseTime = now() - start
+  if (!res.ok) {
+    return { slug: site.slug, status: 'down', code: res.status, responseTime, checkedAt, error: `Statuspage API returned ${res.status}` }
+  }
+
+  // Phase 2: parse and grade. The request already completed, so preserve the
+  // real HTTP status in `code` — a failure here (malformed body, unknown
+  // component) is a payload/config problem, distinct from a network outage,
+  // and collapsing it to `code: 0` would make a persistent misconfiguration
+  // look like transient flakiness in the persisted history.
+  try {
+    const summary = (await res.json()) as StatuspageSummary
+    if (typeof summary !== 'object' || summary === null) {
+      return { slug: site.slug, status: 'down', code: res.status, responseTime, checkedAt, error: 'Statuspage summary.json was not a JSON object' }
+    }
+    return {
+      slug: site.slug,
+      status: deriveStatuspageStatus(summary, site.component),
+      code: res.status,
+      responseTime,
+      checkedAt,
+    }
+  }
+  catch (err) {
+    return {
+      slug: site.slug,
+      status: 'down',
+      code: res.status,
+      responseTime,
+      checkedAt,
       error: err instanceof Error ? err.message : String(err),
     }
   }

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -1,5 +1,6 @@
 import type { Site } from './config'
 import type { CheckResult, CheckStatus } from './types'
+import { z } from 'zod'
 
 /** Minimal fetch signature so callers (and tests) can pass any compatible impl. */
 export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>
@@ -91,11 +92,31 @@ const STATUSPAGE_INDICATOR_STATUS: Record<string, CheckStatus> = {
   maintenance: 'degraded',
 }
 
-/** The slice of an Atlassian Statuspage `summary.json` payload we rely on. */
-export interface StatuspageSummary {
-  status?: { indicator?: string, description?: string }
-  components?: Array<{ id?: string, name?: string, status?: string }>
-}
+/**
+ * The slice of an Atlassian Statuspage `summary.json` payload we rely on.
+ * Validated at the boundary rather than trusting a bare type assertion, so a
+ * response of the wrong shape (a proxy error page, an API version change, a
+ * non-object body) is caught and reported instead of read as a real payload.
+ */
+export const statuspageSummarySchema = z.object({
+  status: z
+    .object({
+      indicator: z.string().optional(),
+      description: z.string().optional(),
+    })
+    .optional(),
+  components: z
+    .array(
+      z.object({
+        id: z.string().optional(),
+        name: z.string().optional(),
+        status: z.string().optional(),
+      }),
+    )
+    .optional(),
+})
+
+export type StatuspageSummary = z.infer<typeof statuspageSummarySchema>
 
 /**
  * Resolve the `summary.json` API URL for a configured Statuspage `url`. A bare
@@ -176,13 +197,16 @@ async function checkStatuspage(site: Site, fetchImpl: FetchLike, now: () => numb
   // and collapsing it to `code: 0` would make a persistent misconfiguration
   // look like transient flakiness in the persisted history.
   try {
-    const summary = (await res.json()) as StatuspageSummary
-    if (typeof summary !== 'object' || summary === null) {
-      return { slug: site.slug, status: 'down', code: res.status, responseTime, checkedAt, error: 'Statuspage summary.json was not a JSON object' }
+    // Validate the shape at the boundary instead of trusting a type assertion.
+    // safeParse also rejects non-objects (null, arrays), so a wrong-shaped body
+    // is reported rather than silently graded.
+    const parsed = statuspageSummarySchema.safeParse(await res.json())
+    if (!parsed.success) {
+      return { slug: site.slug, status: 'down', code: res.status, responseTime, checkedAt, error: `Statuspage summary.json failed validation: ${parsed.error.message}` }
     }
     return {
       slug: site.slug,
-      status: deriveStatuspageStatus(summary, site.component),
+      status: deriveStatuspageStatus(parsed.data, site.component),
       code: res.status,
       responseTime,
       checkedAt,

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -42,6 +42,12 @@ describe('parseConfig', () => {
   it('rejects an empty component string', () => {
     expect(() => parseConfig(`${baseYaml}    check: statuspage\n    component: ""\n`)).toThrow()
   })
+
+  it('rejects component on a non-statuspage check kind', () => {
+    // A mistyped `check` should surface as a parse error, not silently ignore
+    // the component.
+    expect(() => parseConfig(`${baseYaml}    check: http\n    component: Some Service\n`)).toThrow()
+  })
 })
 
 describe('theme.locale', () => {

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -28,6 +28,20 @@ describe('parseConfig', () => {
     // A comma would split the Cache-Tag header into bogus tags.
     expect(() => parseConfig(`${baseYaml}    slug: my,service\n`)).toThrow()
   })
+
+  it('accepts the statuspage check kind with a component', () => {
+    const config = parseConfig(`${baseYaml}    check: statuspage\n    component: Claude API\n`)
+    expect(config.sites[0]?.check).toBe('statuspage')
+    expect(config.sites[0]?.component).toBe('Claude API')
+  })
+
+  it('rejects an unknown check kind', () => {
+    expect(() => parseConfig(`${baseYaml}    check: carrier-pigeon\n`)).toThrow()
+  })
+
+  it('rejects an empty component string', () => {
+    expect(() => parseConfig(`${baseYaml}    check: statuspage\n    component: ""\n`)).toThrow()
+  })
 })
 
 describe('theme.locale', () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -27,7 +27,8 @@ export const siteSchema = z
     /**
      * For `check: statuspage` only. Reads one Atlassian Statuspage component by
      * name (case-insensitive) or id; when omitted, the page's overall indicator
-     * is used. Ignored by other check kinds.
+     * is used. Rejected at parse time for other check kinds (see superRefine
+     * below) so a mistyped `check` doesn't silently ignore the field.
      */
     component: z.string().min(1).optional(),
     /**
@@ -36,6 +37,18 @@ export const siteSchema = z
      * commas/whitespace, which would corrupt the header — see cache.ts).
      */
     slug: z.string().regex(/^[a-z0-9-]+$/, 'slug must be lowercase letters, digits, and hyphens').optional(),
+  })
+  .superRefine((site, ctx) => {
+    // `component` only means something for statuspage checks; surface a mistyped
+    // `check` (or a stray `component:` line) as a parse error instead of quietly
+    // ignoring it at runtime.
+    if (site.component !== undefined && site.check !== 'statuspage') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['component'],
+        message: `component is only valid with check: statuspage (got check: ${site.check})`,
+      })
+    }
   })
   .transform(site => ({ ...site, slug: site.slug ?? slugify(site.name) }))
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { DEFAULT_LOCALE, LOCALES } from './i18n'
 
 /** How a single service is checked. */
-export const checkKindSchema = z.enum(['http', 'tcp', 'ssl'])
+export const checkKindSchema = z.enum(['http', 'tcp', 'ssl', 'statuspage'])
 export type CheckKind = z.infer<typeof checkKindSchema>
 
 /** Turn a human name into a stable, URL-safe slug. */
@@ -24,6 +24,12 @@ export const siteSchema = z
     expectedStatusCodes: z.array(z.number().int()).default([200]),
     /** Response time above this (ms) marks the site `degraded` rather than `up`. */
     maxResponseTime: z.number().int().positive().default(5000),
+    /**
+     * For `check: statuspage` only. Reads one Atlassian Statuspage component by
+     * name (case-insensitive) or id; when omitted, the page's overall indicator
+     * is used. Ignored by other check kinds.
+     */
+    component: z.string().min(1).optional(),
     /**
      * Optional explicit slug; defaults to slugify(name). Constrained to the
      * same charset slugify emits so it's safe to embed in a `Cache-Tag` (no

--- a/status.config.example.yml
+++ b/status.config.example.yml
@@ -6,7 +6,7 @@ name: Acme Status
 sites:
   - name: Website
     url: https://example.com
-    check: http # http | tcp | ssl
+    check: http # http | tcp | ssl | statuspage
     expectedStatusCodes: [200]
     maxResponseTime: 2000 # ms; slower responses are marked "degraded"
   - name: API

--- a/status.config.example.yml
+++ b/status.config.example.yml
@@ -13,6 +13,19 @@ sites:
     url: https://api.example.com/health
     check: http
 
+  # Read status straight from an Atlassian Statuspage (status.claude.com,
+  # *.statuspage.io, vercel-status.com, …). `url` is the page's base URL;
+  # status-please appends /api/v2/summary.json automatically.
+  - name: Claude
+    url: https://status.claude.com
+    check: statuspage
+  # Add `component` to track one service on the page instead of the whole page.
+  # Match by component name (case-insensitive) or id.
+  - name: Claude API
+    url: https://status.claude.com
+    check: statuspage
+    component: Claude API (api.anthropic.com)
+
 # All optional. Keep the real Slack URL in the private config you upload to KV,
 # not in this committed example (the webhook URL is a secret).
 notifications:


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

This adds an Atlassian Statuspage check adapter to the status-please monorepo (a Bun + TypeScript upptime successor). It lets a configured `site` mirror status directly from any Atlassian Statuspage (status.claude.com, *.statuspage.io, vercel-status.com, etc.) via the standard `/api/v2/summary.json` JSON API, either for the whole page's overall indicator or for a single named/id'd component. `checkSite` was refactored into a dispatcher on `site.check`; the new adapter maps the page's overall indicator — or a single configured `component` (by name or id) — to the up/degraded/down model. Only the base page URL is needed; the summary.json path is derived automatically.

Changed files:
- `packages/core/src/config.ts` — `'statuspage'` kind added to `checkKindSchema`, optional `component` field
- `packages/core/src/check.ts` — `checkSite` refactored into a dispatcher; added `checkStatuspage`, `deriveStatuspageStatus`, `statuspageSummaryUrl`
- `packages/core/src/check.test.ts` — 13 new tests
- `status.config.example.yml` — statuspage usage examples added
- `README.md` — statuspage config docs added

## Related issue

<!-- e.g. Closes #123 -->

N/A — no related issue for this PR.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added or updated, and the suite passes (`bun run test`)
- [x] Lint/format pass (`bun run lint`)
- [x] Documentation updated if behavior changed
- [x] No breaking change, or a `BREAKING CHANGE:` note is included

All 98 tests pass (`bun run test`), typecheck and lint are clean, and the adapter was verified end-to-end against live status.claude.com and vercel-status.com endpoints.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `statuspage` check that mirrors health from Atlassian Statuspage `/api/v2/summary.json` for a whole page or a single component. Refactors `checkSite` in `packages/core` to dispatch by `site.check`, validates payloads with a `zod` schema, preserves real HTTP codes, and rejects `component` on non-`statuspage` checks at config parse.

- **New Features**
  - Support `check: statuspage` in `packages/core` with optional `component` (name or id); API URL auto-derived via `statuspageSummaryUrl`.
  - Docs: README “Check types” table and full adapter guide at `docs/adapters/statuspage.md`. Examples and tests cover URL derivation, component matching, and schema/edge cases.

- **Bug Fixes**
  - Preserve real HTTP status for grading failures; differentiate network errors (`code: 0`) from payload/config issues.
  - Validation and edges: `zod`-validate `summary.json` (including non-object/invalid shapes); strip trailing slashes before detecting `/api/v2/*.json`; handle explicit `/api/v2/*.json` with trailing slashes; avoid ReDoS in trailing-slash stripping; trim `component` before id/name match; reject `component` on non-`statuspage` checks with a clear parse error.

<sup>Written for commit 10cd0d2ecda896bfe1a4dd284772c4e0f4166dd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

