### PR TITLE
feat(web): add explicit dark mode theme toggle

### DIFF
--- a/.claude/agent-memory/review-review-silent-failure-hunter/MEMORY.md
+++ b/.claude/agent-memory/review-review-silent-failure-hunter/MEMORY.md
@@ -3,3 +3,4 @@
 - [status-please conventions](status_please_conventions.md) — repo's logging style (plain console.error, no Sentry/errorIds) + known intentional fail-open fallbacks in badge.ts
 - [Project error-handling conventions](project_error_conventions.md) — no Sentry/logError infra; console.error/warn is house style (see apps/worker/src/cache.ts, notify.ts)
 - [i18n feature review 2026-07](i18n_feature_2026_07.md) — amondnet/i18n branch findings: getLocale() silent catch, locale-per-URL architecture, cron Worker's redundant loud config-parse failure
+- [dark-mode theme toggle 2026-07](dark_mode_theme_toggle_2026_07.md) — amondnet/dark-mode: astro anti-FOUC empty catch is fine by design; ThemeToggle.tsx's own unguarded localStorage calls are the real gap, no ErrorBoundary in app

--- a/.claude/agent-memory/review-review-silent-failure-hunter/dark_mode_theme_toggle_2026_07.md
+++ b/.claude/agent-memory/review-review-silent-failure-hunter/dark_mode_theme_toggle_2026_07.md
@@ -1,0 +1,45 @@
+---
+name: dark-mode-theme-toggle-2026-07
+description: Findings from reviewing the amondnet/dark-mode branch (ThemeToggle.tsx + StatusPage.astro anti-FOUC script) for silent failures
+metadata:
+  type: project
+---
+
+Reviewed `amondnet/dark-mode` vs `origin/main` on 2026-07-08 (`git diff origin/main...HEAD`).
+
+Confirmed no React Error Boundary exists anywhere in `apps/web/src` (grep returned zero matches).
+`ThemeToggle` hydrates via `client:load` as its own Astro island root, separate from `StatusList`'s
+`client:visible` island — a crash in one island does not affect the other or the static SSR shell.
+
+## Key finding
+
+`apps/web/src/components/StatusPage.astro:49-54` wraps `localStorage.getItem('theme')` in an
+intentional empty `try/catch` for the anti-FOUC head script — correct-by-design, since this is a
+blocking pre-paint script and the only failure mode is a cosmetic flash of system-default theme.
+This is NOT a bug (see [[status_please_conventions]] for the repo's general "acceptable silent
+degrade" precedents in badge.ts).
+
+However `apps/web/src/components/ThemeToggle.tsx` does the *same* `localStorage` access
+(`readStoredTheme()` at line 33-35, called from a mount `useEffect` at line 50-52) and a write
+(`applyTheme()` at line 20-31, called from the click handler `cycle()` at line 54-58) with **no
+try/catch at all**, despite a comment in the file explicitly acknowledging it should stay "in sync"
+with the astro script's storage contract.
+
+Consequences if `localStorage` throws (Safari private-mode/legacy WebKit, storage disabled via
+policy/extension, partitioned third-party iframe storage):
+- Mount effect (`readStoredTheme`): an uncaught throw inside `useEffect` is caught by React's
+  commit-phase error handling; with no Error Boundary present, React unmounts the whole
+  `ThemeToggle` island — the button silently disappears after first paint, console-only signal.
+- Click handler (`applyTheme` → `cycle`): `classList.toggle` runs before the `localStorage.setItem`
+  call, so the visible theme changes but persistence silently fails, and since the throw prevents
+  `setTheme(next)` from running, the button's icon goes out of sync with the actual `.dark`/`.light`
+  class until the next successful click. On reload the choice reverts with no indication to the user.
+
+Recommended fix (given to the user): wrap both `readStoredTheme()` and the storage calls inside
+`applyTheme()` in try/catch, mirroring the astro script, and keep the DOM class change even if
+persistence fails (session-only theme is an acceptable degrade; total silence about the failure
+mode is not).
+
+Confidence: 82 (mount-effect case, IMPORTANT) and 78 (click-handler case, borderline
+IMPORTANT/MINOR) — not "definitely happens" since modern mainstream browsers rarely throw here,
+but a real and previously-acknowledged-by-the-author risk class.

--- a/apps/web/src/components/StatusPage.astro
+++ b/apps/web/src/components/StatusPage.astro
@@ -6,6 +6,7 @@ import '../styles/global.css'
 import { IncidentList } from './IncidentList'
 import { StatusBanner } from './StatusBanner'
 import { StatusList } from './StatusList'
+import { ThemeToggle } from './ThemeToggle'
 
 // The locale is fixed by the page's URL prefix (/en/, /ja/, …). Each localized
 // page under src/pages/<locale>/ loads the data + cache headers (see
@@ -39,6 +40,19 @@ const localeHref = (l: string): string => new URL(`/${l}/`, Astro.site ?? Astro.
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
     <title>{t.page.title}</title>
+    {/*
+      Anti-FOUC: apply the visitor's remembered theme to <html> before first
+      paint so a forced light/dark choice never flashes the system default.
+      Kept in sync with ThemeToggle.tsx (same storage key + class contract).
+    */}
+    <script is:inline>
+      try {
+        var t = localStorage.getItem('theme')
+        if (t === 'light' || t === 'dark') {
+          document.documentElement.classList.add(t)
+        }
+      } catch (e) {}
+    </script>
     {/* Multilingual SEO: tell crawlers these four URLs are translations of each
         other, with English as the x-default landing. */}
     {LOCALES.map(l => (
@@ -48,6 +62,12 @@ const localeHref = (l: string): string => new URL(`/${l}/`, Astro.site ?? Astro.
   </head>
   <body class="min-h-full">
     <main class="mx-auto max-w-3xl px-4 py-10">
+      {/* Interactive (theme cycle): hydrates as a React island. Right-aligned
+          above the banner, the conventional spot for a theme control. */}
+      <div class="mb-4 flex justify-end">
+        <ThemeToggle locale={locale} client:load />
+      </div>
+
       {/* Static: renders to HTML with 0 JS (shadcn Alert via React SSR). */}
       <div class="mb-8">
         <StatusBanner severity={overall} locale={locale} />

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -63,7 +63,13 @@ export function ThemeToggle({ locale }: Readonly<{ locale: Locale }>) {
   const [theme, setTheme] = useState<Theme>('system')
 
   useEffect(() => {
-    setTheme(readStoredTheme())
+    // Re-apply to <html> too, not just state: normally the anti-FOUC inline
+    // script already set the class, but if it was suppressed (strict CSP with no
+    // 'unsafe-inline', an extension) the island still hydrates — so applyTheme
+    // here keeps the DOM class, icon, and label in sync regardless.
+    const stored = readStoredTheme()
+    applyTheme(stored)
+    setTheme(stored)
   }, [])
 
   const cycle = (): void => {

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,79 @@
+import type { Locale } from '@status-please/core'
+import { getDict } from '@status-please/core'
+import { Monitor, Moon, Sun } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+/**
+ * The three theme choices. `system` follows the OS via the root's
+ * `color-scheme: light dark`; `light`/`dark` force it by toggling the matching
+ * class on <html> (see the `@custom-variant dark` + `.dark`/`.light` blocks in
+ * global.css). Persisted under this key and read back by the inline
+ * anti-FOUC script in StatusPage.astro — keep both in sync.
+ */
+export type Theme = 'light' | 'dark' | 'system'
+export const THEME_STORAGE_KEY = 'theme'
+
+const ORDER: readonly Theme[] = ['system', 'light', 'dark']
+const ICON: Record<Theme, typeof Sun> = { system: Monitor, light: Sun, dark: Moon }
+
+/** Apply a theme to <html> and persist it. Mirrors the inline script's logic. */
+function applyTheme(theme: Theme): void {
+  const root = document.documentElement
+  root.classList.toggle('light', theme === 'light')
+  root.classList.toggle('dark', theme === 'dark')
+  if (theme === 'system') {
+    localStorage.removeItem(THEME_STORAGE_KEY)
+  }
+  else {
+    localStorage.setItem(THEME_STORAGE_KEY, theme)
+  }
+}
+
+function readStoredTheme(): Theme {
+  const stored = localStorage.getItem(THEME_STORAGE_KEY)
+  return stored === 'light' || stored === 'dark' ? stored : 'system'
+}
+
+/**
+ * Cycles system → light → dark → system, forcing the color scheme by toggling
+ * the `.light`/`.dark` class on <html>. Hydrates as a React island; the inline
+ * script in the page head applies the stored choice before paint, so this only
+ * syncs the button's display and handles clicks.
+ */
+export function ThemeToggle({ locale }: Readonly<{ locale: Locale }>) {
+  const t = getDict(locale)
+  // Start from `system` for a stable SSR/first-paint markup, then reconcile with
+  // the persisted choice on mount to avoid a hydration mismatch.
+  const [theme, setTheme] = useState<Theme>('system')
+
+  useEffect(() => {
+    setTheme(readStoredTheme())
+  }, [])
+
+  const cycle = (): void => {
+    const next = ORDER[(ORDER.indexOf(theme) + 1) % ORDER.length] ?? 'system'
+    applyTheme(next)
+    setTheme(next)
+  }
+
+  const Icon = ICON[theme]
+  const label = `${t.a11y.themeToggle}: ${t.theme[theme]}`
+
+  return (
+    <button
+      type="button"
+      onClick={cycle}
+      aria-label={label}
+      title={label}
+      className={cn(
+        'inline-flex size-8 items-center justify-center rounded-md border border-border',
+        'text-muted-foreground transition-colors',
+        'hover:bg-muted hover:text-foreground',
+        'focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none',
+      )}
+    >
+      <Icon className="size-4" aria-hidden="true" />
+    </button>
+  )
+}

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -15,24 +15,39 @@ export type Theme = 'light' | 'dark' | 'system'
 export const THEME_STORAGE_KEY = 'theme'
 
 const ORDER: readonly Theme[] = ['system', 'light', 'dark']
-const ICON: Record<Theme, typeof Sun> = { system: Monitor, light: Sun, dark: Moon }
 
-/** Apply a theme to <html> and persist it. Mirrors the inline script's logic. */
+/**
+ * Apply a theme to <html> and persist it. Mirrors the inline script's logic.
+ * `localStorage` access is guarded because a restrictive environment (Safari
+ * "Block All Cookies", sandboxed iframe, enterprise policy) throws a
+ * SecurityError on any access — the class toggle stays outside the guard so the
+ * visual theme still flips even when persistence is unavailable.
+ */
 function applyTheme(theme: Theme): void {
   const root = document.documentElement
   root.classList.toggle('light', theme === 'light')
   root.classList.toggle('dark', theme === 'dark')
-  if (theme === 'system') {
-    localStorage.removeItem(THEME_STORAGE_KEY)
+  try {
+    if (theme === 'system') {
+      localStorage.removeItem(THEME_STORAGE_KEY)
+    }
+    else {
+      localStorage.setItem(THEME_STORAGE_KEY, theme)
+    }
   }
-  else {
-    localStorage.setItem(THEME_STORAGE_KEY, theme)
+  catch {
+    // Persistence unavailable — the in-page toggle still works for this visit.
   }
 }
 
 function readStoredTheme(): Theme {
-  const stored = localStorage.getItem(THEME_STORAGE_KEY)
-  return stored === 'light' || stored === 'dark' ? stored : 'system'
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY)
+    return stored === 'light' || stored === 'dark' ? stored : 'system'
+  }
+  catch {
+    return 'system'
+  }
 }
 
 /**
@@ -57,7 +72,6 @@ export function ThemeToggle({ locale }: Readonly<{ locale: Locale }>) {
     setTheme(next)
   }
 
-  const Icon = ICON[theme]
   const label = `${t.a11y.themeToggle}: ${t.theme[theme]}`
 
   return (
@@ -70,10 +84,20 @@ export function ThemeToggle({ locale }: Readonly<{ locale: Locale }>) {
         'inline-flex size-8 items-center justify-center rounded-md border border-border',
         'text-muted-foreground transition-colors',
         'hover:bg-muted hover:text-foreground',
-        'focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none',
+        'focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
       )}
     >
-      <Icon className="size-4" aria-hidden="true" />
+      {/*
+        Which icon shows is driven by the `.light`/`.dark` class the inline
+        script sets on <html> before first paint, not by React state — so a
+        returning visitor with a forced theme sees the correct icon immediately,
+        with no post-hydration flash. `system` = neither class → Monitor. The
+        aria-label still comes from state (reconciled in the mount effect); a
+        label that settles a tick after paint is invisible and pre-interaction.
+      */}
+      <Monitor className="size-4 dark:hidden light:hidden" aria-hidden="true" />
+      <Sun className="hidden size-4 light:block" aria-hidden="true" />
+      <Moon className="hidden size-4 dark:block" aria-hidden="true" />
     </button>
   )
 }

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -1,8 +1,11 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
-/* shadcn dark variant (class-based override for a future theme toggle). */
+/* shadcn dark variant + explicit light variant, so the theme toggle can show
+ * the right icon straight from the root class the inline script sets — no JS
+ * state, hence no post-hydration icon flash. `system` = neither class. */
 @custom-variant dark (&:is(.dark, .dark *));
+@custom-variant light (&:is(.light, .light *));
 
 /*
  * Map design tokens to Tailwind's theme so utilities like `bg-background`,

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -47,7 +47,9 @@ export type DayKey = 'up' | 'degraded' | 'down' | 'nodata'
 export interface Dict {
   page: { title: string }
   /** Accessible names for UI chrome (not visible copy), e.g. the switcher nav. */
-  a11y: { languageNav: string }
+  a11y: { languageNav: string, themeToggle: string }
+  /** Theme-toggle mode labels (system-following, forced light, forced dark). */
+  theme: { light: string, dark: string, system: string }
   /** Roll-up banner headline, keyed by overall severity. */
   banner: Record<Severity, string>
   /** Short badge label, keyed by severity. */
@@ -72,7 +74,8 @@ export interface Dict {
 
 const en: Dict = {
   page: { title: 'Status' },
-  a11y: { languageNav: 'Language' },
+  a11y: { languageNav: 'Language', themeToggle: 'Theme' },
+  theme: { light: 'Light', dark: 'Dark', system: 'System' },
   banner: {
     operational: 'All Systems Operational',
     degraded: 'Degraded Performance',
@@ -123,7 +126,8 @@ const en: Dict = {
 
 const zh: Dict = {
   page: { title: '服务状态' },
-  a11y: { languageNav: '语言' },
+  a11y: { languageNav: '语言', themeToggle: '主题' },
+  theme: { light: '浅色', dark: '深色', system: '跟随系统' },
   banner: {
     operational: '所有系统正常',
     degraded: '性能下降',
@@ -174,7 +178,8 @@ const zh: Dict = {
 
 const ja: Dict = {
   page: { title: 'ステータス' },
-  a11y: { languageNav: '言語' },
+  a11y: { languageNav: '言語', themeToggle: 'テーマ' },
+  theme: { light: 'ライト', dark: 'ダーク', system: 'システム' },
   banner: {
     operational: 'すべてのシステムが正常',
     degraded: 'パフォーマンス低下',
@@ -225,7 +230,8 @@ const ja: Dict = {
 
 const ko: Dict = {
   page: { title: '상태' },
-  a11y: { languageNav: '언어' },
+  a11y: { languageNav: '언어', themeToggle: '테마' },
+  theme: { light: '라이트', dark: '다크', system: '시스템' },
   banner: {
     operational: '모든 시스템 정상',
     degraded: '성능 저하',


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

Adds an explicit dark mode theme toggle to the status page. The CSS token
infrastructure for light/dark (`light-dark()`, `.dark`/`.light` classes on
`<html>`) already existed in `global.css` and followed the system preference
automatically; this change adds the missing user-facing control to override it.

## Changes

- `apps/web/src/components/ThemeToggle.tsx` (new): React island that cycles
  system -> light -> dark, toggling the `.light`/`.dark` class on `<html>` and
  persisting the choice to `localStorage['theme']` (removes the key for
  `system`). Uses lucide icons (Monitor/Sun/Moon) and an i18n aria-label.
- `apps/web/src/components/StatusPage.astro`: adds an anti-FOUC inline
  `<script>` in `<head>` that applies the stored theme before first paint, and
  places `<ThemeToggle client:load />` right-aligned above the status banner.
- `packages/core/src/i18n.ts`: adds `a11y.themeToggle` and
  `theme: { light, dark, system }` labels to the `Dict` interface, translated
  across all 4 locales (en/zh/ja/ko).

## Related issue

N/A

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added or updated, and the suite passes (`bun run test`)
- [x] Lint/format pass (`bun run lint`)
- [ ] Documentation updated if behavior changed
- [ ] No breaking change, or a `BREAKING CHANGE:` note is included

## Test Plan

- [x] `bun test i18n` (14 pass)
- [x] `astro check` (0 errors)
- [x] `eslint .` (clean)
- [x] production `astro build` (success)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user-facing theme toggle for system, light, and dark on the status page. The choice is applied before paint to avoid flashes, with resilient sync even if the inline script is blocked.

- **New Features**
  - Added `ThemeToggle` React island that cycles system → light → dark, toggles `.light`/`.dark` on `<html>`, and persists to `localStorage['theme']`. Uses `lucide-react` icons and i18n labels from `@status-please/core`.
  - In `StatusPage.astro`, added an inline pre-paint script to apply the stored theme and placed `<ThemeToggle client:load />` above the banner; extended i18n with `a11y.themeToggle` and `theme.{light,dark,system}` for `en/zh/ja/ko`.

- **Bug Fixes**
  - Guarded `localStorage` access in `ThemeToggle` to handle restricted environments; keeps the DOM class change even if persistence fails.
  - Drove the icon from root `.light`/`.dark` classes via a new `@custom-variant light` in `global.css` to remove post-hydration icon flash; aligned focus ring to `ring-2 ring-ring`.
  - Applied the resolved theme to `<html>` in the mount effect so the DOM class, icon, and label stay in sync when the pre-paint script is blocked (e.g., strict CSP).

<sup>Written for commit b5e8fe9b413426958299ec5211e2b1339e8f1c25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

