### PR TITLE
chore: force first release to 0.1.0 instead of 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "release-type": "node",
       "package-name": "status-please",
       "changelog-path": "CHANGELOG.md",
+      "release-as": "0.1.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false
     }


### PR DESCRIPTION
## Summary

release-please defaults the **initial** release (from a `0.0.0` manifest with no prior tag) to **1.0.0** — regardless of `bump-minor-pre-major`. This is visible in the open release PR #17, which proposes `1.0.0`.

This pins `release-as: "0.1.0"` on the root package so the first release is cut as a pre-1.0 version. Once this merges, release-please will regenerate #17 as **0.1.0**.

## Follow-up (important)
`release-as` is sticky — after the `0.1.0` GitHub Release is cut, **remove `release-as`** from the config so subsequent releases auto-bump (feat → 0.2.0, breaking → 0.x via `bump-minor-pre-major`).

## Notes
- manifest stays `0.0.0` (release-as overrides it for this release)
- no code changes; config only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force the first release to 0.1.0 by setting `release-please` to `release-as: "0.1.0"`, avoiding the default 1.0.0 initial release and keeping pre-1.0 semantics with `bump-minor-pre-major`.

- **Migration**
  - After 0.1.0 is released, remove `release-as` from `release-please-config.json` so future versions auto-bump as configured.

<sup>Written for commit a0161a11e50e08d441b58c415c3558131b13427c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

