### PR TITLE
chore: move demo to demo.statusbeam.dev

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -144,7 +144,7 @@ settings to gate every deploy behind an approval.
 
   ```text
   // in apps/web/wrangler.jsonc
-  "routes": [{ "pattern": "demo.status.pleaseai.dev", "custom_domain": true }]
+  "routes": [{ "pattern": "demo.statusbeam.dev", "custom_domain": true }]
   ```
 
   Two caveats: (1) adding a route **disables the `*.workers.dev` URL** — add

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_statusbeam&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_statusbeam)
 [![codecov](https://codecov.io/gh/pleaseai/statusbeam/graph/badge.svg)](https://codecov.io/gh/pleaseai/statusbeam)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
-[![Live demo](https://img.shields.io/badge/live%20demo-demo.status.pleaseai.dev-brightgreen)](https://demo.status.pleaseai.dev)
+[![Live demo](https://img.shields.io/badge/live%20demo-demo.statusbeam.dev-brightgreen)](https://demo.statusbeam.dev)
 [![Deploy on Cloudflare](https://img.shields.io/badge/deploy%20on-Cloudflare-F38020?logo=cloudflare&logoColor=white)](./DEPLOYMENT.md)
 
 > An open-source, CDN-native **status page** generator — the modern successor to [upptime](https://github.com/upptime/upptime).
 
-🔗 **Live demo:** [demo.status.pleaseai.dev](https://demo.status.pleaseai.dev) — a StatusBeam instance monitoring a few public services, running on Cloudflare.
+🔗 **Live demo:** [demo.statusbeam.dev](https://demo.statusbeam.dev) — a StatusBeam instance monitoring a few public services, running on Cloudflare.
 
 StatusBeam monitors your services, records their uptime as durable time-series
 data, and publishes a fast, good-looking status page to the edge. It keeps the parts
@@ -36,7 +36,7 @@ public JSON API — while fixing upptime's biggest structural weaknesses:
 🚧 **Active development.** The core pipeline is live end-to-end — HTTP checks on
 Cloudflare Cron write to D1/KV, the Astro page renders 90-day uptime bars, response-time
 charts, and an incident timeline at the edge, and status changes fan out to Slack/webhooks
-while purging the edge cache. A [live demo](https://demo.status.pleaseai.dev) runs on
+while purging the edge cache. A [live demo](https://demo.statusbeam.dev) runs on
 Cloudflare. TCP/SSL checks, a public API + badges, and more notification channels are
 next — see the [Roadmap](#roadmap).
 

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -7,7 +7,7 @@
   "compatibility_flags": ["nodejs_compat"],
 
   // Custom domain: Cloudflare provisions the proxied DNS record + edge cert
-  // automatically (the `pleaseai.dev` zone lives in this account). The page is
+  // automatically (the `statusbeam.dev` zone lives in this account). The page is
   // still reachable at the *.workers.dev URL too.
   "routes": [{ "pattern": "demo.statusbeam.dev", "custom_domain": true }],
 

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -9,7 +9,7 @@
   // Custom domain: Cloudflare provisions the proxied DNS record + edge cert
   // automatically (the `pleaseai.dev` zone lives in this account). The page is
   // still reachable at the *.workers.dev URL too.
-  "routes": [{ "pattern": "demo.status.pleaseai.dev", "custom_domain": true }],
+  "routes": [{ "pattern": "demo.statusbeam.dev", "custom_domain": true }],
 
   // Workers Cache: a tiered edge cache in front of this Worker. Rendered pages
   // set Cache-Control + stale-while-revalidate; hits skip the Worker and D1,


### PR DESCRIPTION
Points the live demo custom domain at the new `statusbeam.dev` zone after the StatusBeam rename.

## Changes
- `apps/web/wrangler.jsonc` — custom-domain route `demo.status.pleaseai.dev` → `demo.statusbeam.dev`
- `README.md` — live-demo badge + links
- `DEPLOYMENT.md` — custom-domain example

## Already applied to production
Deployed via wrangler OAuth (the CI token is scoped to the `pleaseai.dev` zone and lacks `statusbeam.dev` Workers Routes/DNS Edit, which a custom-domain *change* requires):
- `statusbeam-web` now serves **demo.statusbeam.dev** (zone `statusbeam.dev`, edge cert issued)
- old `demo.status.pleaseai.dev` binding removed

Committed `wrangler.jsonc` keeps the CI ID placeholders (real IDs were injected only for the local deploy, then reverted).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the live demo to https://demo.statusbeam.dev after the StatusBeam rename. Updated the custom-domain route in `apps/web/wrangler.jsonc`, fixed the zone name in its comment, and refreshed README/DEPLOYMENT links.

<sup>Written for commit b42faa5253d01f576b104cf37c2fec5dc1a864f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

