### PR TITLE
docs: reword upptime positioning from "successor" to "a modern take"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Live demo](https://img.shields.io/badge/live%20demo-demo.statusbeam.dev-brightgreen)](https://demo.statusbeam.dev)
 [![Deploy on Cloudflare](https://img.shields.io/badge/deploy%20on-Cloudflare-F38020?logo=cloudflare&logoColor=white)](./DEPLOYMENT.md)
 
-> An open-source, CDN-native **status page** generator — the modern successor to [upptime](https://github.com/upptime/upptime).
+> An open-source, CDN-native **status page** generator — a modern take on [upptime](https://github.com/upptime/upptime).
 
 🔗 **Live demo:** [demo.statusbeam.dev](https://demo.statusbeam.dev) — a StatusBeam instance monitoring a few public services, running on Cloudflare.
 

--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     starlight({
       title: 'StatusBeam',
       description:
-        'Open-source, CDN-native status page generator — a modern successor to upptime.',
+        'Open-source, CDN-native status page generator — a modern take on upptime.',
       logo: { src: './src/assets/logo.svg', alt: 'StatusBeam' },
       social: [
         {
@@ -59,7 +59,7 @@ export default defineConfig({
         starlightLlmsTxt({
           projectName: 'StatusBeam',
           description:
-            'Open-source, CDN-native status page generator — a modern successor to upptime. Runs on Cloudflare (Workers, Cron Triggers, D1, KV).',
+            'Open-source, CDN-native status page generator — a modern take on upptime. Runs on Cloudflare (Workers, Cron Triggers, D1, KV).',
         }),
         // Exposes every page as clean, AST-transformed raw Markdown for agents
         // and crawlers. Pinned to `.md.txt` so it owns a namespace distinct from

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: StatusBeam
-description: Open-source, CDN-native status page generator — a modern successor to upptime.
+description: Open-source, CDN-native status page generator — a modern take on upptime.
 template: splash
 hero:
-  tagline: An open-source, CDN-native status page generator — the modern successor to upptime. Renders every byte at the edge from its own store, so your page never hits third-party rate limits.
+  tagline: An open-source, CDN-native status page generator — a modern take on upptime. Renders every byte at the edge from its own store, so your page never hits third-party rate limits.
   image:
     file: ../../assets/logo.svg
   actions:

--- a/docs/adr/0001-tech-stack.md
+++ b/docs/adr/0001-tech-stack.md
@@ -7,7 +7,7 @@
 ## Context
 
 StatusBeam is an open-source status page generator, conceived as a modern
-successor to [upptime](https://github.com/upptime/upptime). We need to choose a
+take on [upptime](https://github.com/upptime/upptime). We need to choose a
 **frontend framework**, a **check/scheduling mechanism**, a **data store**, and a
 **deploy target**. Two hard requirements shaped the decision:
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "private": true,
   "packageManager": "bun@1.3.14",
-  "description": "Open-source, CDN-native status page generator — a modern successor to upptime.",
+  "description": "Open-source, CDN-native status page generator — a modern take on upptime.",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

Rewords StatusBeam's positioning relative to upptime: "the modern successor to upptime" / "a modern successor to upptime" → "a modern take on upptime".

upptime is still actively maintained and there is no sanctioned lineage or endorsement from that project, so "successor" overstated the relationship. "A modern take on" keeps the "modern" framing that motivates the comparison without implying an official/endorsed succession.

Applied consistently across:
- `README.md` — project tagline
- `package.json` — `description` field
- `apps/docs/astro.config.ts` — Starlight `description` and `starlightLlmsTxt` `description`
- `apps/docs/src/content/docs/index.mdx` — frontmatter `description` and hero `tagline`
- `docs/adr/0001-tech-stack.md` — ADR 0001 context prose

The GitHub repo description was already updated separately via `gh repo edit` (out of scope for this PR's diff).

## Related issue

<!-- e.g. Closes #123 -->

N/A — wording/positioning cleanup, no linked issue.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added or updated, and the suite passes (`bun run test`) — N/A, docs/wording-only change
- [x] Lint/format pass (`bun run lint`)
- [x] Documentation updated if behavior changed — this PR *is* the documentation update
- [x] No breaking change, or a `BREAKING CHANGE:` note is included — no breaking change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworded StatusBeam’s positioning from “modern successor” to “a modern take on upptime” to avoid implying endorsement while keeping the modern framing. Updated the tagline/description in README, package.json, docs config and homepage, and ADR 0001.

<sup>Written for commit 76ee8488495362875e81d941700fa594d95caa3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

