### PR TITLE
feat(docs): serve docs via Cloudflare Pages with pages.dev asset CDN

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,8 +1,10 @@
 name: Deploy Docs
 
-# The documentation site (apps/docs) is a static Starlight build served from
-# Cloudflare Workers Static Assets. It has no D1/KV or config dependencies, so it
-# deploys independently of the production status page (see deploy.yml).
+# The documentation site (apps/docs) is a static Starlight build deployed to a
+# Cloudflare Pages project (statusbeam-docs). It has no D1/KV or config
+# dependencies, so it deploys independently of the production status page (see
+# deploy.yml). CLOUDFLARE_API_TOKEN must include the "Cloudflare Pages: Edit"
+# permission (Workers-only tokens will fail the pages deploy).
 on:
   workflow_dispatch:
   push:

--- a/apps/docs/.claude/skills/run-docs/SKILL.md
+++ b/apps/docs/.claude/skills/run-docs/SKILL.md
@@ -7,7 +7,9 @@ allowed-tools: Bash, Read
 # Run the StatusBeam docs site (`apps/docs`)
 
 Static **Astro + Starlight** documentation site. It builds to `./dist` and is
-served on Cloudflare via Workers Static Assets (no server, no D1/KV). The AI
+deployed to a Cloudflare **Pages** project (no server, no D1/KV) — served at
+`docs.statusbeam.dev`, with bundled assets loaded from `statusbeam-docs.pages.dev`
+(`build.assetsPrefix`). The AI
 surface — `/llms.txt`, `/llms-full.txt`, per-page `.md.txt` raw Markdown, and the
 "Copy Markdown" / "Open in ChatGPT·Claude" buttons — is what most edits touch.
 
@@ -76,11 +78,13 @@ Useful for editing content; not needed for verification.
 ## Deploy
 
 ```bash
-bun run --filter '@statusbeam/docs' deploy    # astro build && wrangler deploy
+bun run --filter '@statusbeam/docs' deploy    # astro build && wrangler pages deploy --branch=main
 ```
 
-Needs `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`. CI does this via
-`.github/workflows/deploy-docs.yml` on merge to `main`.
+Needs `CLOUDFLARE_API_TOKEN` (with **Cloudflare Pages: Edit**) + `CLOUDFLARE_ACCOUNT_ID`,
+and the `statusbeam-docs` Pages project must already exist
+(`bunx wrangler pages project create statusbeam-docs --production-branch main`). CI
+does this via `.github/workflows/deploy-docs.yml` on merge to `main`.
 
 ## Gotchas
 

--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -14,6 +14,15 @@ export default defineConfig({
   // starlight-llms-txt (llms.txt / llms-full.txt), the sitemap, and the
   // "Open in ChatGPT/Claude" page actions (which pass `Astro.url.href`).
   site: 'https://docs.statusbeam.dev',
+  // Serve bundled assets (`_astro/*` JS, CSS, fonts, images) from the Cloudflare
+  // Pages project origin, decoupled from the page host. Pages are reached at `site`
+  // (docs.statusbeam.dev — a custom domain on the same Pages project); their bundled
+  // assets load from statusbeam-docs.pages.dev. Because that makes the module scripts
+  // and @font-face cross-origin, the asset origin must send CORS — see public/_headers.
+  // https://docs.astro.build/en/reference/configuration-reference/#buildassetsprefix
+  build: {
+    assetsPrefix: 'https://statusbeam-docs.pages.dev',
+  },
   integrations: [
     starlight({
       title: 'StatusBeam',

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "wrangler dev",
-    "deploy": "astro build && wrangler deploy",
-    "deploy:publish": "wrangler deploy",
+    "preview": "wrangler pages dev ./dist",
+    "deploy": "astro build && wrangler pages deploy --branch=main",
+    "deploy:publish": "wrangler pages deploy --branch=main",
     "typecheck": "astro check"
   },
   "dependencies": {

--- a/apps/docs/public/_headers
+++ b/apps/docs/public/_headers
@@ -1,0 +1,9 @@
+# Cloudflare Pages headers rules. https://developers.cloudflare.com/pages/configuration/headers/
+#
+# Pages are served at docs.statusbeam.dev, but their bundled assets load from
+# statusbeam-docs.pages.dev (build.assetsPrefix in astro.config.ts). That makes the
+# `_astro/*` bundles cross-origin. ES module scripts and @font-face are always
+# fetched in CORS mode, so the asset origin must allow cross-origin reads or the
+# browser blocks them. These are public, read-only static assets, so `*` is safe.
+/_astro/*
+  Access-Control-Allow-Origin: *

--- a/apps/docs/src/content/docs/guides/deployment.mdx
+++ b/apps/docs/src/content/docs/guides/deployment.mdx
@@ -49,14 +49,24 @@ ships a scripted path and a manual one — the outline below mirrors the repo's
 ## Deploying these docs
 
 This documentation site is a separate app (`apps/docs`). It is a fully static
-Starlight build served from Cloudflare via **Workers Static Assets** — no D1/KV,
-no server adapter:
+Starlight build deployed to a **Cloudflare Pages** project (`statusbeam-docs`) —
+no D1/KV, no server adapter:
 
 ```bash
 bun run --filter '@statusbeam/docs' deploy
 ```
 
+The site is reached at **`docs.statusbeam.dev`** (a custom domain on the Pages
+project), while its bundled assets (`_astro/*` JS, CSS, fonts) load from the
+project's own **`statusbeam-docs.pages.dev`** origin. That split is configured via
+Astro's [`build.assetsPrefix`](https://docs.astro.build/en/reference/configuration-reference/#buildassetsprefix)
+in `astro.config.ts`; the cross-origin assets are made CORS-readable by
+`public/_headers`.
+
 <Aside type="note">
-  See the repo's `DEPLOYMENT.md` for the full, authoritative deployment guide,
-  including troubleshooting and the exact `wrangler` commands.
+  One-time setup on Cloudflare: create the Pages project
+  (`bunx wrangler pages project create statusbeam-docs --production-branch main`)
+  and attach the `docs.statusbeam.dev` custom domain in the dashboard
+  (Pages → your project → Custom domains). The deploy token needs the
+  **Cloudflare Pages: Edit** permission.
 </Aside>

--- a/apps/docs/wrangler.jsonc
+++ b/apps/docs/wrangler.jsonc
@@ -3,21 +3,18 @@
   "name": "statusbeam-docs",
   "compatibility_date": "2026-07-01",
 
-  // Static-assets-only Worker: the Starlight build in ./dist is served directly
-  // from Cloudflare's edge, with no Worker script (`main`). llms.txt, the
-  // `.md.txt` endpoints, and the copied `.md` files are all plain static files
-  // in dist, so they are served as-is.
-  // https://developers.cloudflare.com/workers/static-assets/
-  "assets": {
-    "directory": "./dist",
-    // Docs URLs are extensionless (/getting-started/quick-start). Let the edge
-    // resolve them to the prerendered .html without a redirect.
-    "html_handling": "auto-trailing-slash",
-    "not_found_handling": "404-page"
-  },
+  // Cloudflare Pages project. The Starlight build in ./dist is uploaded and served
+  // from Cloudflare's edge. Pages resolves extensionless URLs to the prerendered
+  // .html and falls back to the generated 404.html automatically — no asset-routing
+  // config needed (unlike Workers Static Assets). llms.txt, the `.md.txt` endpoints,
+  // and the copied `.md` files are plain static files in dist, served as-is.
+  // https://developers.cloudflare.com/pages/configuration/
+  "pages_build_output_dir": "./dist"
 
-  // Custom domain: Cloudflare provisions the proxied DNS record + edge cert
-  // automatically (the statusbeam.dev zone lives in this account). Also reachable
-  // at the *.workers.dev URL. Change or remove for your own deployment.
-  "routes": [{ "pattern": "docs.statusbeam.dev", "custom_domain": true }]
+  // Domains are NOT configured here:
+  //   • Access domain — the custom domain `docs.statusbeam.dev` is attached to this
+  //     Pages project via the Cloudflare dashboard (Pages → Custom domains) or API.
+  //   • Asset (CDN) origin — bundled assets load from this project's own
+  //     `statusbeam-docs.pages.dev` URL, set as `build.assetsPrefix` in astro.config.ts.
+  // Unlike Workers `routes`, Pages custom domains have no wrangler.jsonc equivalent.
 }


### PR DESCRIPTION
## Summary

Migrates the docs site (`apps/docs`) from Cloudflare Workers Static Assets to Cloudflare Pages, and serves bundled assets from a separate CDN origin.

- `apps/docs/astro.config.ts` — added `build.assetsPrefix: 'https://statusbeam-docs.pages.dev'` so `_astro/*` bundles load from the Pages project origin; `site` stays `https://docs.statusbeam.dev`.
- `apps/docs/wrangler.jsonc` — replaced the Workers `assets`/`routes` config with Pages `pages_build_output_dir: "./dist"`.
- `apps/docs/public/_headers` — new file adding `Access-Control-Allow-Origin: *` on `/_astro/*` so the cross-origin module scripts and fonts are CORS-readable.
- `apps/docs/package.json` — deploy/preview scripts switched from `wrangler` to `wrangler pages` (with `--branch=main` for production).
- `.github/workflows/deploy-docs.yml` — updated comment; token now needs "Cloudflare Pages: Edit".
- `apps/docs/src/content/docs/guides/deployment.mdx` and `apps/docs/.claude/skills/run-docs/SKILL.md` — doc updates reflecting the Pages migration and the CDN/custom-domain split.

The pages are reached at `docs.statusbeam.dev` (a custom domain on the Pages project) while bundled assets load from `statusbeam-docs.pages.dev`.

## Related issue

N/A

## Checklist

- [x] PR title follows Conventional Commits
- [ ] Tests added or updated, and the suite passes (`bun run test`)
- [ ] Lint/format pass (`bun run lint`)
- [x] Documentation updated if behavior changed
- [x] No breaking change, or a `BREAKING CHANGE:` note is included

Verified: build passes, live deploy serves the site with CORS headers on assets, and canonical/sitemap/llms.txt still use `docs.statusbeam.dev`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the docs site (`apps/docs`) from Workers Static Assets to Cloudflare Pages and serves `_astro/*` bundles from the Pages origin. Pages stay on `docs.statusbeam.dev`, assets load from `statusbeam-docs.pages.dev` with CORS enabled.

- **Migration**
  - `astro.config.ts`: set `build.assetsPrefix: 'https://statusbeam-docs.pages.dev'`; `site` remains `https://docs.statusbeam.dev`.
  - `public/_headers`: add `Access-Control-Allow-Origin: *` for `/_astro/*` to allow cross-origin modules and fonts.
  - `wrangler.jsonc`: replace Workers `assets`/`routes` with Pages `pages_build_output_dir: "./dist"`; custom domains handled in the dashboard.
  - `package.json`: switch preview/deploy to `wrangler pages` (prod uses `--branch=main`).
  - `.github/workflows/deploy-docs.yml`: note token must include “Cloudflare Pages: Edit”.
  - Docs: update deployment guide and SKILL to reflect Pages and the domain/CDN split.

<sup>Written for commit 4bc27f97ff540d1bea8c30e2f87f7396560221d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

