### PR TITLE
chore(demo): monitor GitHub/Cloudflare/npm via the statuspage adapter

### DIFF
--- a/status.config.yml
+++ b/status.config.yml
@@ -6,21 +6,21 @@
 name: statusbeam Demo
 
 sites:
-  - name: GitHub API
-    url: https://api.github.com
-    check: http
-    expectedStatusCodes: [200]
-    maxResponseTime: 2000
+  # Statuspage adapter — mirror each vendor's own published verdict (their
+  # /api/v2/summary.json) instead of a naive reachability ping. GitHub, Cloudflare
+  # and npm all publish an Atlassian Statuspage. See docs/adapters/statuspage.md.
+  - name: GitHub
+    url: https://www.githubstatus.com
+    check: statuspage
   - name: Cloudflare
-    url: https://www.cloudflare.com
-    check: http
-    expectedStatusCodes: [200]
-    maxResponseTime: 2000
-  - name: npm Registry
-    url: https://registry.npmjs.org
-    check: http
-    expectedStatusCodes: [200]
-    maxResponseTime: 3000
+    url: https://www.cloudflarestatus.com
+    check: statuspage
+  - name: npm
+    url: https://status.npmjs.org
+    check: statuspage
+    component: Package installation
+
+  # One plain http check for contrast — a direct reachability probe.
   - name: Cloudflare DNS
     url: https://1.1.1.1
     check: http


### PR DESCRIPTION
## Summary

Switch the hosted demo (`demo.statusbeam.dev`) from plain `http` reachability pings to the **`statuspage` adapter** for the vendors that publish an Atlassian Statuspage — a better showcase of the adapter with real, component-level data.

| Site | Before | After |
| --- | --- | --- |
| GitHub | `http` api.github.com | `statuspage` www.githubstatus.com |
| Cloudflare | `http` cloudflare.com | `statuspage` www.cloudflarestatus.com |
| npm | `http` registry.npmjs.org | `statuspage` status.npmjs.org (component: Package installation) |
| Cloudflare DNS | `http` 1.1.1.1 | `http` 1.1.1.1 (kept, for contrast) |

Keeping one `http` check means the demo shows both check kinds side by side.

## Why

The demo exists to show off this product; mirroring each vendor's own published verdict is more on-message than a naive reachability ping, and surfaces component-level status.

## Verification

Ran the real `checkSite` against the live pages via the core package:

```
github         status=up        code=200
cloudflare     status=degraded  code=200   # matches its live 'minor' indicator
npm            status=up        code=200
cloudflare-dns status=up        code=200
```

Config also validated through `parseConfig` (all slugs derive correctly; the npm `component` resolves against the live page).

## Notes

- **Webhooks aren't used here.** Inbound Statuspage webhooks require the upstream page to offer webhook subscriptions; GitHub/Cloudflare/npm only expose email/SMS/Slack/RSS to public subscribers, so the demo stays on cron for these. (The webhook path — #33 — is for a Statuspage you own.)
- No related issue.

## Related issue

_None._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the hosted demo (`demo.statusbeam.dev`) from plain `http` pings to the `statuspage` adapter for GitHub, Cloudflare, and npm to show real, component-level status. Keep one `http` check (Cloudflare DNS at 1.1.1.1) for contrast.

- **New Features**
  - GitHub via `statuspage`: https://www.githubstatus.com
  - Cloudflare via `statuspage`: https://www.cloudflarestatus.com
  - npm via `statuspage`: https://status.npmjs.org with `component: Package installation`
  - Cloudflare DNS remains `http`: https://1.1.1.1

<sup>Written for commit 40750a5ad8a40e06930a9151b59fcb7597240e21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

