### PR TITLE
chore: format .claude/settings.json with prettier

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,17 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "language": "english",
-  "enabledPlugins": {
-    "astro@pleaseai": true,
-    "claude-md-management@pleaseai": true,
-    "bun@pleaseai": true,
-    "turborepo@pleaseai": true
-  },
-  "extraKnownMarketplaces": {
-    "pleaseai": {
-      "source": { "source": "github", "repo": "pleaseai/claude-code-plugins" },
-      "autoUpdate": true
-    }
+  "env": {
+    "ENABLE_TOOL_SEARCH": "true",
+    "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS": "40000"
   },
   "permissions": {
     "deny": [
@@ -21,8 +12,20 @@
       "Read(./.dev.vars.*)"
     ]
   },
-  "env": {
-    "ENABLE_TOOL_SEARCH": "true",
-    "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS": "40000"
-  }
+  "enabledPlugins": {
+    "astro@pleaseai": true,
+    "claude-md-management@pleaseai": true,
+    "bun@pleaseai": true,
+    "turborepo@pleaseai": true
+  },
+  "extraKnownMarketplaces": {
+    "pleaseai": {
+      "source": {
+        "source": "github",
+        "repo": "pleaseai/claude-code-plugins"
+      },
+      "autoUpdate": true
+    }
+  },
+  "language": "english"
 }


### PR DESCRIPTION
## Summary

Applies prettier formatting to `.claude/settings.json`. This is a **pure formatting change** — the settings are semantically identical (byte-for-byte equivalent when normalized with `jq -S`).

## What changed
- Reorders top-level keys: `env` and `permissions` moved above `enabledPlugins`; `language` moved to the bottom.
- Expands the marketplace `source` object to multi-line.

## Verification
- `diff <(git show HEAD:.claude/settings.json | jq -S .) <(jq -S . .claude/settings.json)` → identical.
- `bunx prettier .claude/settings.json` output matches the committed file.

No behavioral change to the Claude Code setup (plugins, permissions, env, language all preserved).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formatted .claude/settings.json with `prettier` to standardize JSON layout and improve readability. Only key order and the marketplace source formatting changed; no semantic or behavior changes.

<sup>Written for commit d5daba3800683bfe5ef3dc2242ea5b79c1343be4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

