### PR TITLE
feat(worker): optional Cloudflare Queues path for reliable notification delivery

### DIFF
--- a/.claude/agent-memory/review-review-comment-analyzer/MEMORY.md
+++ b/.claude/agent-memory/review-review-comment-analyzer/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory Index
+
+- [statusbeam-queue-notify-comments](statusbeam-queue-notify-comments.md) — notify.ts/wrangler.jsonc doc-comment findings on the Cloudflare Queues path (issue #42)

--- a/.claude/agent-memory/review-review-comment-analyzer/statusbeam-queue-notify-comments.md
+++ b/.claude/agent-memory/review-review-comment-analyzer/statusbeam-queue-notify-comments.md
@@ -1,0 +1,44 @@
+---
+name: statusbeam-queue-notify-comments
+description: Doc-comment accuracy findings for the Cloudflare Queues notification path added in issue #42 (notify.ts, wrangler.jsonc) — useful if this branch/PR is re-reviewed or the pattern recurs elsewhere.
+metadata:
+  type: project
+---
+
+Reviewed `git diff origin/main...HEAD` on `amondnet/42` (Cloudflare Queues opt-in
+notification delivery). Two real findings, otherwise the diff's extensive new
+JSDoc was accurate and cross-checked cleanly against `notify.test.ts`.
+
+1. **apps/worker/wrangler.jsonc:47-48** (Important, confidence 78) — comment
+   says "The `scheduled` producer then enqueues..." but `notify()` (where
+   enqueueing happens) is reached via `ingest()`, which is called from BOTH
+   `index.ts`'s `scheduled` handler AND the webhook `fetch` handler
+   (`webhook.ts:116` → `handleStatuspageWebhook` → `ingest`). The comment
+   undersells that inbound Statuspage subscriber webhooks also enqueue to
+   NOTIFY_QUEUE, not just the 5-min cron tick. Same prose does NOT appear in
+   `packages/create-statusbeam/templates/wrangler.worker.jsonc` (that one is
+   trigger-agnostic and correct) — only the main worker's own wrangler.jsonc
+   has this specific overclaim.
+
+2. **apps/worker/src/notify.ts:72** (Minor, confidence 45) — `dispatchNotifications`'s
+   doc says "(called from `ctx.waitUntil`)", stale from before this diff when
+   that was literally true. Now `ingest.ts:68` calls
+   `ctx.waitUntil(notify(env, ...))` and `notify()` calls `dispatchNotifications`
+   internally as its fallback branch — one level removed, and also called
+   directly in tests with no waitUntil at all.
+
+**Why this matters for future reviews**: this repo (chatbot-pf/pleaseai OSS,
+`statusbeam`) has a strong convention of rich, precise doc-comments (see
+`notify.ts`, `env.ts`, `wrangler.jsonc`) that reference concrete call sites and
+entrypoints (e.g. "called from ctx.waitUntil", "the scheduled producer").
+That precision is a strength but also the exact failure mode to check first
+when a refactor moves a call up/down a call chain — the comment tends to keep
+naming the *old* direct caller instead of being updated or genericized.
+
+**How to apply**: When reviewing future diffs in this repo that touch
+`notify.ts`, `index.ts`, `ingest.ts`, or `webhook.ts`, explicitly trace which
+functions call `ingest()`/`notify()` before trusting any comment that names a
+specific trigger (`scheduled`, `fetch`, cron) as "the" producer/caller — this
+codebase has multiple entrypoints funneling into the same pipeline
+(`index.ts:9` documents this pattern: "Two triggers feed the same `ingest`
+pipeline").

--- a/.claude/agent-memory/review-review-silent-failure-hunter/MEMORY.md
+++ b/.claude/agent-memory/review-review-silent-failure-hunter/MEMORY.md
@@ -7,3 +7,4 @@
 - [setup scripts error handling (PR #22)](setup_scripts_error_handling.md) — D1/KV lookup swallow + apply-config.ts setNetworking/setCron fallbacks — all fixed in PR #22 (lookups return non-zero on wr failure; setNetworking/setCron now throw)
 - [CLI/scaffolder error handling (PR #30)](cli_scaffolder_error_handling_pr30.md) — packages/cli + create-statusbeam port of setup.sh; PR #22 fixes carried forward; new injectIds stale-id-on-rerun gap found
 - [statuspage webhook ingest 2026-07](statuspage_webhook_ingest_2026_07.md) — amondnet/statuspage-webhook: webhook.ts reject paths (400/401/404) log nothing (gap); fallback chains and degraded-default confirmed sound, not new regressions
+- [notify queue delivery 2026-07](notify_queue_delivery_2026_07.md) — amondnet/42: unguarded NOTIFY_QUEUE.sendBatch() drops whole batch silently on throw; ack()/retry() conflation risk in consumer

--- a/.claude/agent-memory/review-review-silent-failure-hunter/notify_queue_delivery_2026_07.md
+++ b/.claude/agent-memory/review-review-silent-failure-hunter/notify_queue_delivery_2026_07.md
@@ -1,0 +1,50 @@
+---
+name: notify-queue-delivery-2026-07
+description: amondnet/42 (Cloudflare Queues notification delivery) findings — unguarded NOTIFY_QUEUE.sendBatch enqueue path, ack/retry conflation edge case in the queue consumer
+metadata:
+  type: project
+---
+
+Branch `amondnet/42` (issue #42) adds an opt-in Cloudflare Queues delivery path for
+notifications in `apps/worker/src/notify.ts`. Two dispatch modes: inline
+(`dispatchNotifications`/`postJson`, intentionally swallows + logs, never throws —
+by design so one bad target can't wedge a cron run) and queue
+(`consumeNotificationBatch`, must throw/retry so Queues re-delivers and
+eventually dead-letters — `deliverNotification` throws on non-2xx/network error,
+consumer catches and calls `message.retry()`).
+
+Reviewed 2026-07-08. Two real gaps found, distinct from the swallow-vs-throw
+design the PR got right elsewhere:
+
+1. **Unguarded enqueue call** (notify.ts ~line 59): `await
+   env.NOTIFY_QUEUE.sendBatch(...)` inside `notify()` has no try/catch. If it
+   throws (CF Queues message-size/batch-size limits, quota, transient API
+   error), the rejection propagates out of `notify()` through
+   `ctx.waitUntil(notify(...))` in `ingest.ts` (~line 68) with none of the
+   "notify:"-prefixed contextual logging every other failure path in this file
+   has. Unlike the documented missing-binding fallback (which warns + degrades
+   to inline), an enqueue-time throw drops the *entire batch* silently (no
+   fallback, no retry — ironic since queue mode exists specifically for
+   retry/DLQ guarantees). `notify.test.ts` has no test for `sendBatch`
+   rejecting, confirming the gap. Recommended fix: wrap the `sendBatch` call in
+   try/catch, log with `console.error('notify: enqueue failed ...', err)`
+   including target count, and consider falling back to inline dispatch (same
+   pattern already used for the missing-binding case) rather than dropping the
+   batch.
+
+2. **ack()/retry() not independently guarded** (consumeNotificationBatch,
+   notify.ts ~lines 101-108): `message.ack()` is called inside the same `try`
+   as `deliverNotification`. If `ack()` itself throws post-delivery-success,
+   the catch block logs the misleading "queue delivery failed, retrying" (delivery
+   actually succeeded) and calls `message.retry()` — causing a duplicate
+   delivery. If `retry()` itself then also throws, the exception is uncaught,
+   propagates through `consumeNotificationBatch` → `queue()` in `index.ts`
+   (no try/catch there either), and per Cloudflare Queues semantics a handler
+   throw retries the *whole batch*, including messages that had already
+   ack'd/delivered successfully — a duplicate-delivery risk for unrelated
+   messages in the same batch. Low likelihood (ack/retry are Workers-runtime
+   calls, rarely throw) but zero test coverage for this edge case either.
+
+See also [[project_error_conventions]] (house style: plain console.error/warn,
+no Sentry/errorIds infra — both gaps above should be fixed with that same
+plain-logging style, not by introducing new infra).

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -8,9 +8,10 @@ export interface Env {
   /**
    * Optional Cloudflare Queue for reliable notification delivery. Bound only
    * when the operator opts into `notifications.delivery: queue` and wires the
-   * `queues.producers` binding in wrangler.jsonc (Workers Paid plan). When
-   * unset, dispatch falls back to inline `fetch` (see {@link notify} in
-   * notify.ts). The `queue()` consumer in index.ts drains it with retries + DLQ.
+   * `queues.producers` binding in wrangler.jsonc (Queues is on the free plan;
+   * the Paid plan raises limits and retention). When unset, dispatch falls back
+   * to inline `fetch` (see {@link notify} in notify.ts). The `queue()` consumer
+   * in index.ts drains it with retries + DLQ.
    */
   NOTIFY_QUEUE?: Queue<NotificationMessage>
   /**

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -1,8 +1,18 @@
+import type { NotificationMessage } from './notify'
+
 export interface Env {
   /** Time-series checks + incident history. */
   DB: D1Database
   /** Current snapshot the status page reads, plus the `config` YAML document. */
   STATUS_KV: KVNamespace
+  /**
+   * Optional Cloudflare Queue for reliable notification delivery. Bound only
+   * when the operator opts into `notifications.delivery: queue` and wires the
+   * `queues.producers` binding in wrangler.jsonc (Workers Paid plan). When
+   * unset, dispatch falls back to inline `fetch` (see {@link notify} in
+   * notify.ts). The `queue()` consumer in index.ts drains it with retries + DLQ.
+   */
+  NOTIFY_QUEUE?: Queue<NotificationMessage>
   /**
    * Cloudflare API token with the "Cache Purge" permission. Used by
    * {@link purgeStatusCache} to purge the edge cache by Cache-Tag on a status

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,6 +1,8 @@
 import type { Env } from './env'
+import type { NotificationMessage } from './notify'
 import { checkSite } from '@statusbeam/core'
 import { ingest, loadConfig } from './ingest'
+import { consumeNotificationBatch } from './notify'
 import { handleStatuspageWebhook } from './webhook'
 
 /**
@@ -14,6 +16,13 @@ import { handleStatuspageWebhook } from './webhook'
  *
  * Both persist the result, refresh the snapshot the status page reads, and — on
  * a status change — notify subscribers and purge the edge cache.
+ *
+ * A third, opt-in trigger drains notifications when `notifications.delivery` is
+ * `queue`:
+ *
+ * - `queue` (Cloudflare Queues): dispatch each enqueued notification with the
+ *   queue's automatic retries + dead-lettering. Inert unless the operator wires
+ *   the `queues` bindings in wrangler.jsonc (Workers Paid plan).
  */
 export default {
   async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
@@ -24,5 +33,9 @@ export default {
 
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     return handleStatuspageWebhook(request, env, ctx)
+  },
+
+  async queue(batch: MessageBatch<NotificationMessage>, _env: Env, _ctx: ExecutionContext): Promise<void> {
+    await consumeNotificationBatch(batch)
   },
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -22,7 +22,8 @@ import { handleStatuspageWebhook } from './webhook'
  *
  * - `queue` (Cloudflare Queues): dispatch each enqueued notification with the
  *   queue's automatic retries + dead-lettering. Inert unless the operator wires
- *   the `queues` bindings in wrangler.jsonc (Workers Paid plan).
+ *   the `queues` bindings in wrangler.jsonc (Queues runs on the free plan; the
+ *   Paid plan raises limits and retention).
  */
 export default {
   async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {

--- a/apps/worker/src/ingest.ts
+++ b/apps/worker/src/ingest.ts
@@ -3,7 +3,7 @@ import type { Env } from './env'
 import { buildStatusChangePayload, formatUptime, parseConfig, windowUptime } from '@statusbeam/core'
 import { purgeStatusCache } from './cache'
 import { KV_KEYS } from './env'
-import { dispatchNotifications } from './notify'
+import { notify } from './notify'
 
 const HISTORY_DAYS = 90
 
@@ -63,8 +63,9 @@ export async function ingest(
     const payload = buildStatusChangePayload(changes, new Date().toISOString())
 
     // Notify subscribers and purge the edge cache by tag so the page reflects
-    // the new state immediately instead of waiting for its TTL.
-    ctx.waitUntil(dispatchNotifications(config.notifications, payload))
+    // the new state immediately instead of waiting for its TTL. `notify` picks
+    // inline `fetch` or the opt-in Cloudflare Queue from `notifications.delivery`.
+    ctx.waitUntil(notify(env, config.notifications, payload))
     ctx.waitUntil(purgeStatusCache(env, changes.map(c => c.slug)))
   }
 }

--- a/apps/worker/src/notify.test.ts
+++ b/apps/worker/src/notify.test.ts
@@ -1,0 +1,178 @@
+import type { StatusChangePayload } from '@statusbeam/core'
+import type { Env } from './env'
+import type { NotificationMessage } from './notify'
+import { buildStatusChangePayload } from '@statusbeam/core'
+import { describe, expect, it } from 'bun:test'
+import {
+  buildNotificationMessages,
+  consumeNotificationBatch,
+  deliverNotification,
+  dispatchNotifications,
+  notify,
+} from './notify'
+
+const payload: StatusChangePayload = buildStatusChangePayload(
+  [{ slug: 'api', from: 'up', to: 'down' }],
+  '2026-07-08T00:00:00.000Z',
+)
+
+/** A fetch stub recording calls and returning a chosen response/behaviour. */
+function fakeFetch(behaviour: (url: string) => { ok: boolean, status: number } | Error) {
+  const calls: { url: string, body: unknown }[] = []
+  const impl = (async (url: string, init?: RequestInit) => {
+    calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined })
+    const result = behaviour(url)
+    if (result instanceof Error) {
+      throw result
+    }
+    return { ok: result.ok, status: result.status } as Response
+  }) as unknown as typeof fetch
+  return { impl, calls }
+}
+
+describe('buildNotificationMessages', () => {
+  it('returns an empty list when notifications are absent', () => {
+    expect(buildNotificationMessages(undefined, payload)).toEqual([])
+  })
+
+  it('emits one message per target: slack (Block Kit) + each webhook (payload)', () => {
+    const messages = buildNotificationMessages(
+      {
+        delivery: 'inline',
+        slack: { webhookUrl: 'https://hooks.slack.com/services/T/B/X' },
+        webhooks: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+      },
+      payload,
+    )
+    expect(messages.map(m => m.url)).toEqual([
+      'https://hooks.slack.com/services/T/B/X',
+      'https://example.com/a',
+      'https://example.com/b',
+    ])
+    // Slack gets a formatted message; generic webhooks get the raw payload.
+    expect((messages[0]?.body as { blocks: unknown[] }).blocks.length).toBeGreaterThan(0)
+    expect(messages[1]?.body).toEqual(payload)
+  })
+})
+
+describe('deliverNotification', () => {
+  const message: NotificationMessage = { url: 'https://example.com/hook', body: payload }
+
+  it('resolves on a 2xx response', async () => {
+    const { impl, calls } = fakeFetch(() => ({ ok: true, status: 200 }))
+    await expect(deliverNotification(message, impl)).resolves.toBeUndefined()
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.body).toEqual(payload)
+  })
+
+  it('throws on a non-2xx response (so the queue retries)', async () => {
+    const { impl } = fakeFetch(() => ({ ok: false, status: 500 }))
+    await expect(deliverNotification(message, impl)).rejects.toThrow(/500/)
+  })
+
+  it('propagates a thrown fetch (network failure)', async () => {
+    const { impl } = fakeFetch(() => new Error('network down'))
+    await expect(deliverNotification(message, impl)).rejects.toThrow('network down')
+  })
+})
+
+describe('dispatchNotifications (inline)', () => {
+  it('POSTs every target and swallows a failing one', async () => {
+    const { impl, calls } = fakeFetch(url =>
+      url.includes('/bad') ? { ok: false, status: 500 } : { ok: true, status: 200 },
+    )
+    await dispatchNotifications(
+      { delivery: 'inline', webhooks: [{ url: 'https://example.com/ok' }, { url: 'https://example.com/bad' }] },
+      payload,
+      impl,
+    )
+    // Both were attempted; the 500 did not throw or block the other.
+    expect(calls.map(c => c.url)).toEqual(['https://example.com/ok', 'https://example.com/bad'])
+  })
+})
+
+/** A minimal Env whose NOTIFY_QUEUE records the batches it is sent. */
+function queueEnv(withBinding: boolean) {
+  const sent: { body: NotificationMessage }[][] = []
+  const env = {
+    NOTIFY_QUEUE: withBinding
+      ? { sendBatch: async (msgs: { body: NotificationMessage }[]) => { sent.push([...msgs]) } }
+      : undefined,
+  } as unknown as Env
+  return { env, sent }
+}
+
+describe('notify (transport selection)', () => {
+  it('enqueues one message per target when delivery is queue', async () => {
+    const { env, sent } = queueEnv(true)
+    await notify(
+      env,
+      {
+        delivery: 'queue',
+        slack: { webhookUrl: 'https://hooks.slack.com/services/T/B/X' },
+        webhooks: [{ url: 'https://example.com/a' }],
+      },
+      payload,
+    )
+    expect(sent).toHaveLength(1)
+    expect(sent[0]?.map(m => m.body.url)).toEqual([
+      'https://hooks.slack.com/services/T/B/X',
+      'https://example.com/a',
+    ])
+  })
+
+  it('does not enqueue when there are no targets', async () => {
+    const { env, sent } = queueEnv(true)
+    await notify(env, { delivery: 'queue' }, payload)
+    expect(sent).toHaveLength(0)
+  })
+
+  it('falls back to inline when delivery is queue but the binding is missing', async () => {
+    const { env } = queueEnv(false)
+    // No targets → the inline fallback builds zero messages and makes no network
+    // call; we only need the missing-binding branch to resolve (not throw or
+    // silently require a queue). The inline dispatch itself is covered above.
+    await expect(notify(env, { delivery: 'queue' }, payload)).resolves.toBeUndefined()
+  })
+})
+
+/** Build a MessageBatch stub whose messages record ack()/retry() calls. */
+function batchOf(messages: NotificationMessage[]) {
+  const outcomes: ('ack' | 'retry')[] = []
+  const batch = {
+    messages: messages.map(body => ({
+      body,
+      ack: () => outcomes.push('ack'),
+      retry: () => outcomes.push('retry'),
+    })),
+  } as unknown as MessageBatch<NotificationMessage>
+  return { batch, outcomes }
+}
+
+describe('consumeNotificationBatch (queue consumer)', () => {
+  it('acks a message that delivers successfully', async () => {
+    const { impl } = fakeFetch(() => ({ ok: true, status: 200 }))
+    const { batch, outcomes } = batchOf([{ url: 'https://example.com/ok', body: payload }])
+    await consumeNotificationBatch(batch, impl)
+    expect(outcomes).toEqual(['ack'])
+  })
+
+  it('retries a message whose target fails (so Queues re-delivers / dead-letters)', async () => {
+    const { impl } = fakeFetch(() => ({ ok: false, status: 503 }))
+    const { batch, outcomes } = batchOf([{ url: 'https://example.com/bad', body: payload }])
+    await consumeNotificationBatch(batch, impl)
+    expect(outcomes).toEqual(['retry'])
+  })
+
+  it('settles each message independently within a batch', async () => {
+    const { impl } = fakeFetch(url =>
+      url.includes('/bad') ? { ok: false, status: 500 } : { ok: true, status: 200 },
+    )
+    const { batch, outcomes } = batchOf([
+      { url: 'https://example.com/ok', body: payload },
+      { url: 'https://example.com/bad', body: payload },
+    ])
+    await consumeNotificationBatch(batch, impl)
+    expect(outcomes).toEqual(['ack', 'retry'])
+  })
+})

--- a/apps/worker/src/notify.test.ts
+++ b/apps/worker/src/notify.test.ts
@@ -197,6 +197,21 @@ describe('consumeNotificationBatch (queue consumer)', () => {
     expect(outcomes).toEqual(['retry'])
   })
 
+  it('swallows a post-delivery ack failure without retrying (no duplicate POST)', async () => {
+    const { impl } = fakeFetch(() => ({ ok: true, status: 200 }))
+    let retried = false
+    const batch = {
+      messages: [{
+        body: { url: 'https://example.com/ok', body: payload },
+        ack: () => { throw new Error('already settled') },
+        retry: () => { retried = true },
+      }],
+    } as unknown as MessageBatch<NotificationMessage>
+    // Delivery succeeded, so a failing ack must not escalate to a retry.
+    await expect(consumeNotificationBatch(batch, impl)).resolves.toBeUndefined()
+    expect(retried).toBe(false)
+  })
+
   it('settles each message independently within a batch', async () => {
     const { impl } = fakeFetch(url =>
       url.includes('/bad') ? { ok: false, status: 500 } : { ok: true, status: 200 },

--- a/apps/worker/src/notify.test.ts
+++ b/apps/worker/src/notify.test.ts
@@ -147,6 +147,31 @@ describe('notify (transport selection)', () => {
     expect(sent[1]).toHaveLength(51)
   })
 
+  it('dispatches only the un-enqueued remainder inline when a later chunk fails', async () => {
+    // First sendBatch (100) succeeds, the second throws — the already-queued
+    // 100 must NOT be re-POSTed inline (that would double-deliver them); only
+    // the 51-message remainder falls back.
+    let call = 0
+    const enqueued: number[] = []
+    const env = {
+      NOTIFY_QUEUE: {
+        sendBatch: async (msgs: unknown[]) => {
+          call += 1
+          if (call === 1) {
+            enqueued.push(msgs.length)
+            return
+          }
+          throw new Error('queue backlog full')
+        },
+      },
+    } as unknown as Env
+    const { impl, calls } = fakeFetch(() => ({ ok: true, status: 200 }))
+    const webhooks = Array.from({ length: 150 }, (_, i) => ({ url: `https://example.com/${i}` }))
+    await notify(env, { delivery: 'queue', slack: { webhookUrl: 'https://hooks.slack.com/services/T/B/X' }, webhooks }, payload, impl)
+    expect(enqueued).toEqual([100]) // first chunk queued
+    expect(calls).toHaveLength(51) // only the remainder POSTed inline — no double-delivery
+  })
+
   it('routes to inline dispatch for the default (inline) delivery mode', async () => {
     const { env, sent } = queueEnv('record')
     const { impl, calls } = fakeFetch(() => ({ ok: true, status: 200 }))

--- a/apps/worker/src/notify.test.ts
+++ b/apps/worker/src/notify.test.ts
@@ -248,6 +248,20 @@ describe('consumeNotificationBatch (queue consumer)', () => {
     expect(retried).toBe(false)
   })
 
+  it('fails the batch when retry() throws, so the message is redelivered (not silently acked)', async () => {
+    const { impl } = fakeFetch(() => ({ ok: false, status: 503 }))
+    const batch = {
+      messages: [{
+        body: { url: 'https://example.com/bad', body: payload },
+        ack: () => {},
+        retry: () => { throw new Error('retry unavailable') },
+      }],
+    } as unknown as MessageBatch<NotificationMessage>
+    // Delivery failed and retry() couldn't be recorded — the handler must reject
+    // rather than return (a return would let Queues implicitly ack = drop it).
+    await expect(consumeNotificationBatch(batch, impl)).rejects.toThrow('retry unavailable')
+  })
+
   it('settles each message independently within a batch', async () => {
     const { impl } = fakeFetch(url =>
       url.includes('/bad') ? { ok: false, status: 500 } : { ok: true, status: 200 },

--- a/apps/worker/src/notify.test.ts
+++ b/apps/worker/src/notify.test.ts
@@ -136,6 +136,17 @@ describe('notify (transport selection)', () => {
     expect(sent).toHaveLength(0)
   })
 
+  it('chunks a large target list into <=100-message sendBatch calls', async () => {
+    const { env, sent } = queueEnv('record')
+    // 150 webhooks + 1 slack = 151 messages → two batches (100 + 51).
+    const webhooks = Array.from({ length: 150 }, (_, i) => ({ url: `https://example.com/${i}` }))
+    await notify(env, { delivery: 'queue', slack: { webhookUrl: 'https://hooks.slack.com/services/T/B/X' }, webhooks }, payload)
+    // 100 + 51 = 151 → every message enqueued exactly once, no chunk-boundary loss.
+    expect(sent).toHaveLength(2)
+    expect(sent[0]).toHaveLength(100)
+    expect(sent[1]).toHaveLength(51)
+  })
+
   it('routes to inline dispatch for the default (inline) delivery mode', async () => {
     const { env, sent } = queueEnv('record')
     const { impl, calls } = fakeFetch(() => ({ ok: true, status: 200 }))

--- a/apps/worker/src/notify.test.ts
+++ b/apps/worker/src/notify.test.ts
@@ -91,20 +91,25 @@ describe('dispatchNotifications (inline)', () => {
   })
 })
 
-/** A minimal Env whose NOTIFY_QUEUE records the batches it is sent. */
-function queueEnv(withBinding: boolean) {
+/**
+ * A minimal Env whose NOTIFY_QUEUE records the batches it is sent. `binding`:
+ * 'record' captures the enqueued batches, 'throw' simulates an enqueue failure
+ * (quota/throttle/transient API error), 'none' omits the binding entirely.
+ */
+function queueEnv(binding: 'record' | 'throw' | 'none') {
   const sent: { body: NotificationMessage }[][] = []
-  const env = {
-    NOTIFY_QUEUE: withBinding
-      ? { sendBatch: async (msgs: { body: NotificationMessage }[]) => { sent.push([...msgs]) } }
-      : undefined,
-  } as unknown as Env
+  const queue = {
+    record: { sendBatch: async (msgs: { body: NotificationMessage }[]) => { sent.push([...msgs]) } },
+    throw: { sendBatch: async () => { throw new Error('queue backlog full') } },
+    none: undefined,
+  }[binding]
+  const env = { NOTIFY_QUEUE: queue } as unknown as Env
   return { env, sent }
 }
 
 describe('notify (transport selection)', () => {
   it('enqueues one message per target when delivery is queue', async () => {
-    const { env, sent } = queueEnv(true)
+    const { env, sent } = queueEnv('record')
     await notify(
       env,
       {
@@ -119,20 +124,41 @@ describe('notify (transport selection)', () => {
       'https://hooks.slack.com/services/T/B/X',
       'https://example.com/a',
     ])
+    // The enqueued body content survives the { body } wrap: Slack gets its
+    // formatted message, the generic webhook gets the raw payload.
+    expect((sent[0]?.[0]?.body.body as { blocks: unknown[] }).blocks.length).toBeGreaterThan(0)
+    expect(sent[0]?.[1]?.body.body).toEqual(payload)
   })
 
   it('does not enqueue when there are no targets', async () => {
-    const { env, sent } = queueEnv(true)
+    const { env, sent } = queueEnv('record')
     await notify(env, { delivery: 'queue' }, payload)
     expect(sent).toHaveLength(0)
   })
 
-  it('falls back to inline when delivery is queue but the binding is missing', async () => {
-    const { env } = queueEnv(false)
-    // No targets → the inline fallback builds zero messages and makes no network
-    // call; we only need the missing-binding branch to resolve (not throw or
-    // silently require a queue). The inline dispatch itself is covered above.
-    await expect(notify(env, { delivery: 'queue' }, payload)).resolves.toBeUndefined()
+  it('routes to inline dispatch for the default (inline) delivery mode', async () => {
+    const { env, sent } = queueEnv('record')
+    const { impl, calls } = fakeFetch(() => ({ ok: true, status: 200 }))
+    await notify(env, { delivery: 'inline', webhooks: [{ url: 'https://example.com/a' }] }, payload, impl)
+    // Never touched the queue; POSTed the target directly.
+    expect(sent).toHaveLength(0)
+    expect(calls.map(c => c.url)).toEqual(['https://example.com/a'])
+  })
+
+  it('falls back to inline (with a real POST) when delivery is queue but the binding is missing', async () => {
+    const { env } = queueEnv('none')
+    const { impl, calls } = fakeFetch(() => ({ ok: true, status: 200 }))
+    await notify(env, { delivery: 'queue', webhooks: [{ url: 'https://example.com/a' }] }, payload, impl)
+    // The fallback actually dispatched the target rather than silently no-oping.
+    expect(calls.map(c => c.url)).toEqual(['https://example.com/a'])
+  })
+
+  it('falls back to inline (with a real POST) when the enqueue itself fails', async () => {
+    const { env } = queueEnv('throw')
+    const { impl, calls } = fakeFetch(() => ({ ok: true, status: 200 }))
+    await notify(env, { delivery: 'queue', webhooks: [{ url: 'https://example.com/a' }] }, payload, impl)
+    // sendBatch threw → the alert is not dropped; it is delivered inline.
+    expect(calls.map(c => c.url)).toEqual(['https://example.com/a'])
   })
 })
 
@@ -159,6 +185,13 @@ describe('consumeNotificationBatch (queue consumer)', () => {
 
   it('retries a message whose target fails (so Queues re-delivers / dead-letters)', async () => {
     const { impl } = fakeFetch(() => ({ ok: false, status: 503 }))
+    const { batch, outcomes } = batchOf([{ url: 'https://example.com/bad', body: payload }])
+    await consumeNotificationBatch(batch, impl)
+    expect(outcomes).toEqual(['retry'])
+  })
+
+  it('retries a message whose delivery throws (network failure)', async () => {
+    const { impl } = fakeFetch(() => new Error('network down'))
     const { batch, outcomes } = batchOf([{ url: 'https://example.com/bad', body: payload }])
     await consumeNotificationBatch(batch, impl)
     expect(outcomes).toEqual(['retry'])

--- a/apps/worker/src/notify.ts
+++ b/apps/worker/src/notify.ts
@@ -66,21 +66,26 @@ export async function notify(
       if (messages.length === 0) {
         return
       }
+      // Chunk to the sendBatch limit so a large target list still takes the
+      // queue path instead of erroring straight into the inline fallback.
+      let enqueued = 0
       try {
-        // Chunk to the sendBatch limit so a large target list still takes the
-        // queue path instead of erroring straight into the inline fallback.
         for (let i = 0; i < messages.length; i += QUEUE_BATCH_LIMIT) {
-          await env.NOTIFY_QUEUE.sendBatch(
-            messages.slice(i, i + QUEUE_BATCH_LIMIT).map(body => ({ body })),
-          )
+          const chunk = messages.slice(i, i + QUEUE_BATCH_LIMIT)
+          await env.NOTIFY_QUEUE.sendBatch(chunk.map(body => ({ body })))
+          enqueued += chunk.length
         }
         return
       }
       catch (err) {
-        // Enqueue failed — don't drop the alert. Log with the same `notify:`
-        // style as the rest of the file (target count, never payload contents)
-        // and fall through to inline so delivery is still attempted.
-        console.error(`notify: enqueue of ${messages.length} message(s) failed; falling back to inline dispatch`, err)
+        // A chunk failed to enqueue. `sendBatch` is atomic per call, so
+        // `enqueued` counts only fully-accepted chunks — fall back to inline for
+        // just the un-enqueued remainder. Re-dispatching the already-queued
+        // messages would double-deliver them. Log with the file's `notify:`
+        // style (counts, never payload contents).
+        console.error(`notify: enqueue failed after ${enqueued}/${messages.length} message(s); dispatching the rest inline`, err)
+        await postAll(fetchImpl, messages.slice(enqueued))
+        return
       }
     }
     else {
@@ -106,7 +111,11 @@ export async function dispatchNotifications(
   payload: StatusChangePayload,
   fetchImpl: typeof fetch = fetch,
 ): Promise<void> {
-  const messages = buildNotificationMessages(notifications, payload)
+  await postAll(fetchImpl, buildNotificationMessages(notifications, payload))
+}
+
+/** POST every message inline, swallowing individual failures. */
+async function postAll(fetchImpl: typeof fetch, messages: NotificationMessage[]): Promise<void> {
   await Promise.allSettled(messages.map(m => postJson(fetchImpl, m)))
 }
 
@@ -132,7 +141,15 @@ export async function consumeNotificationBatch(
         // dead-letters. Keep `ack()` out of this try so a post-success ack
         // failure isn't misread as a delivery failure and spuriously retried.
         console.error(`notify: queue delivery failed, retrying`, err)
-        message.retry()
+        try {
+          message.retry()
+        }
+        catch (retryErr) {
+          // A thrown retry() would escape Promise.all and abort the whole
+          // batch (re-delivering already-settled messages). Contain it — Queues
+          // re-delivers an unsettled message on its own.
+          console.error(`notify: retry() failed`, retryErr)
+        }
         return
       }
       try {

--- a/apps/worker/src/notify.ts
+++ b/apps/worker/src/notify.ts
@@ -141,15 +141,13 @@ export async function consumeNotificationBatch(
         // dead-letters. Keep `ack()` out of this try so a post-success ack
         // failure isn't misread as a delivery failure and spuriously retried.
         console.error(`notify: queue delivery failed, retrying`, err)
-        try {
-          message.retry()
-        }
-        catch (retryErr) {
-          // A thrown retry() would escape Promise.all and abort the whole
-          // batch (re-delivering already-settled messages). Contain it — Queues
-          // re-delivers an unsettled message on its own.
-          console.error(`notify: retry() failed`, retryErr)
-        }
+        // Do NOT swallow a retry() failure: an unsettled message is implicitly
+        // acked when the handler returns, so swallowing here would silently drop
+        // a notification that failed to deliver. Let it propagate — the batch
+        // fails and Queues redelivers the message. (A settle call throwing is a
+        // near-impossible runtime edge; when it does, redelivering — duplicates
+        // and all — beats dropping an alert.)
+        message.retry()
         return
       }
       try {

--- a/apps/worker/src/notify.ts
+++ b/apps/worker/src/notify.ts
@@ -152,6 +152,10 @@ export async function deliverNotification(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(message.body),
+    // Cap a slow/hung target so it can't stall the queue consumer (or hold an
+    // inline `ctx.waitUntil`). A timeout aborts as a throw → the consumer
+    // retries (transient), the inline path swallows it.
+    signal: AbortSignal.timeout(10_000),
   })
   if (!res.ok) {
     throw new Error(`POST ${redactUrl(message.url)} failed (${res.status})`)

--- a/apps/worker/src/notify.ts
+++ b/apps/worker/src/notify.ts
@@ -43,37 +43,54 @@ export function buildNotificationMessages(
  *   consumer dispatches them with the queue's retries + dead-lettering.
  * - `inline` (default): POST each target directly here.
  *
- * If `delivery: queue` is set but the queue binding is absent (misconfiguration,
- * or the free plan where Queues is unavailable), it falls back to inline so a
- * status change is never silently dropped — and warns the operator.
+ * Falls back to inline dispatch — so a status change is never silently dropped —
+ * whenever the queue path can't be taken:
+ * - the queue binding is absent (misconfiguration, or the free plan where Queues
+ *   is unavailable), or
+ * - the enqueue itself fails (`sendBatch` throws on a quota/throttle/transient
+ *   API error).
+ * Both cases warn the operator so the misconfiguration or outage is visible.
  */
 export async function notify(
   env: Env,
   notifications: Notifications | undefined,
   payload: StatusChangePayload,
+  fetchImpl: typeof fetch = fetch,
 ): Promise<void> {
   if (notifications?.delivery === 'queue') {
     if (env.NOTIFY_QUEUE) {
       const messages = buildNotificationMessages(notifications, payload)
-      if (messages.length > 0) {
-        await env.NOTIFY_QUEUE.sendBatch(messages.map(body => ({ body })))
+      if (messages.length === 0) {
+        return
       }
-      return
+      try {
+        await env.NOTIFY_QUEUE.sendBatch(messages.map(body => ({ body })))
+        return
+      }
+      catch (err) {
+        // Enqueue failed — don't drop the alert. Log with the same `notify:`
+        // style as the rest of the file (target count, never payload contents)
+        // and fall through to inline so delivery is still attempted.
+        console.error(`notify: enqueue of ${messages.length} message(s) failed; falling back to inline dispatch`, err)
+      }
     }
-    console.warn(
-      'notify: notifications.delivery is "queue" but the NOTIFY_QUEUE binding is missing; '
-      + 'add the queues.producers binding in wrangler.jsonc. Falling back to inline dispatch.',
-    )
+    else {
+      console.warn(
+        'notify: notifications.delivery is "queue" but the NOTIFY_QUEUE binding is missing; '
+        + 'add the queues.producers binding in wrangler.jsonc. Falling back to inline dispatch.',
+      )
+    }
   }
-  await dispatchNotifications(notifications, payload)
+  await dispatchNotifications(notifications, payload, fetchImpl)
 }
 
 /**
- * Inline dispatch: POST every target directly (called from `ctx.waitUntil`).
- * Failures are logged, never thrown, so one bad target cannot wedge the run and
- * a status change still reaches the healthy targets. Best-effort — no retries;
- * the {@link notify} queue path is the opt-in reliable alternative. Resolves
- * once every dispatch settles.
+ * Inline dispatch: POST every target directly (the default transport {@link notify}
+ * selects, and its fallback when the queue path is unavailable). Failures are
+ * logged, never thrown, so one bad target cannot wedge the run and a status
+ * change still reaches the healthy targets. Best-effort — no retries; the
+ * {@link notify} queue path is the opt-in reliable alternative. Resolves once
+ * every dispatch settles.
  */
 export async function dispatchNotifications(
   notifications: Notifications | undefined,
@@ -100,12 +117,16 @@ export async function consumeNotificationBatch(
     batch.messages.map(async (message) => {
       try {
         await deliverNotification(message.body, fetchImpl)
-        message.ack()
       }
       catch (err) {
+        // Delivery failed — retry so Queues re-delivers and eventually
+        // dead-letters. Keep `ack()` out of this try so a post-success ack
+        // failure isn't misread as a delivery failure and spuriously retried.
         console.error(`notify: queue delivery failed, retrying`, err)
         message.retry()
+        return
       }
+      message.ack()
     }),
   )
 }

--- a/apps/worker/src/notify.ts
+++ b/apps/worker/src/notify.ts
@@ -13,6 +13,9 @@ export interface NotificationMessage {
   body: unknown
 }
 
+/** Cloudflare Queues caps a single `sendBatch` at 100 messages. */
+const QUEUE_BATCH_LIMIT = 100
+
 /**
  * Fan a status-change payload out into one {@link NotificationMessage} per
  * configured target. Shared by both delivery modes so they dispatch to exactly
@@ -64,7 +67,13 @@ export async function notify(
         return
       }
       try {
-        await env.NOTIFY_QUEUE.sendBatch(messages.map(body => ({ body })))
+        // Chunk to the sendBatch limit so a large target list still takes the
+        // queue path instead of erroring straight into the inline fallback.
+        for (let i = 0; i < messages.length; i += QUEUE_BATCH_LIMIT) {
+          await env.NOTIFY_QUEUE.sendBatch(
+            messages.slice(i, i + QUEUE_BATCH_LIMIT).map(body => ({ body })),
+          )
+        }
         return
       }
       catch (err) {

--- a/apps/worker/src/notify.ts
+++ b/apps/worker/src/notify.ts
@@ -1,32 +1,132 @@
 import type { Notifications, StatusChangePayload } from '@statusbeam/core'
+import type { Env } from './env'
 import { toSlackMessage } from '@statusbeam/core'
 
 /**
- * Fan out a status-change payload to every configured target. Slack receives
- * its Block Kit message; generic webhooks receive the channel-agnostic payload
- * as JSON. Failures are logged, never thrown, so one bad target cannot wedge
- * the cron run. Resolves once every dispatch settles.
+ * A single ready-to-POST notification: one target URL and its JSON body. Slack
+ * carries its Block Kit message; generic webhooks carry the channel-agnostic
+ * payload. This is the wire shape for both delivery modes — inline dispatch
+ * POSTs it directly; queue dispatch enqueues it as one message.
+ */
+export interface NotificationMessage {
+  url: string
+  body: unknown
+}
+
+/**
+ * Fan a status-change payload out into one {@link NotificationMessage} per
+ * configured target. Shared by both delivery modes so they dispatch to exactly
+ * the same set of targets with the same bodies.
+ */
+export function buildNotificationMessages(
+  notifications: Notifications | undefined,
+  payload: StatusChangePayload,
+): NotificationMessage[] {
+  if (!notifications) {
+    return []
+  }
+  const messages: NotificationMessage[] = []
+  if (notifications.slack) {
+    messages.push({ url: notifications.slack.webhookUrl, body: toSlackMessage(payload) })
+  }
+  for (const hook of notifications.webhooks ?? []) {
+    messages.push({ url: hook.url, body: payload })
+  }
+  return messages
+}
+
+/**
+ * Deliver a status-change payload, picking the transport from
+ * `notifications.delivery` (see {@link Notifications}):
  *
- * This is inline dispatch via `fetch` (called from `ctx.waitUntil`). A
- * Cloudflare Workers Queue could sit between producer and dispatch for retries
- * and backpressure; see the follow-up note in wrangler.jsonc.
+ * - `queue`: enqueue one message per target onto {@link Env.NOTIFY_QUEUE} so a
+ *   consumer dispatches them with the queue's retries + dead-lettering.
+ * - `inline` (default): POST each target directly here.
+ *
+ * If `delivery: queue` is set but the queue binding is absent (misconfiguration,
+ * or the free plan where Queues is unavailable), it falls back to inline so a
+ * status change is never silently dropped — and warns the operator.
+ */
+export async function notify(
+  env: Env,
+  notifications: Notifications | undefined,
+  payload: StatusChangePayload,
+): Promise<void> {
+  if (notifications?.delivery === 'queue') {
+    if (env.NOTIFY_QUEUE) {
+      const messages = buildNotificationMessages(notifications, payload)
+      if (messages.length > 0) {
+        await env.NOTIFY_QUEUE.sendBatch(messages.map(body => ({ body })))
+      }
+      return
+    }
+    console.warn(
+      'notify: notifications.delivery is "queue" but the NOTIFY_QUEUE binding is missing; '
+      + 'add the queues.producers binding in wrangler.jsonc. Falling back to inline dispatch.',
+    )
+  }
+  await dispatchNotifications(notifications, payload)
+}
+
+/**
+ * Inline dispatch: POST every target directly (called from `ctx.waitUntil`).
+ * Failures are logged, never thrown, so one bad target cannot wedge the run and
+ * a status change still reaches the healthy targets. Best-effort — no retries;
+ * the {@link notify} queue path is the opt-in reliable alternative. Resolves
+ * once every dispatch settles.
  */
 export async function dispatchNotifications(
   notifications: Notifications | undefined,
   payload: StatusChangePayload,
   fetchImpl: typeof fetch = fetch,
 ): Promise<void> {
-  if (!notifications) {
-    return
+  const messages = buildNotificationMessages(notifications, payload)
+  await Promise.allSettled(messages.map(m => postJson(fetchImpl, m)))
+}
+
+/**
+ * Queue consumer: deliver each message, acking on success and retrying on
+ * failure. Cloudflare Queues re-delivers retried messages with backoff and,
+ * once `max_retries` is exhausted, routes them to the configured dead-letter
+ * queue — so a persistently failing target surfaces there, never silently
+ * dropped. Messages are settled independently so one bad target doesn't force
+ * healthy ones to redeliver.
+ */
+export async function consumeNotificationBatch(
+  batch: MessageBatch<NotificationMessage>,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  await Promise.all(
+    batch.messages.map(async (message) => {
+      try {
+        await deliverNotification(message.body, fetchImpl)
+        message.ack()
+      }
+      catch (err) {
+        console.error(`notify: queue delivery failed, retrying`, err)
+        message.retry()
+      }
+    }),
+  )
+}
+
+/**
+ * POST one notification message. Throws on a network error or a non-2xx
+ * response so the queue consumer retries (and eventually dead-letters) it. The
+ * inline path wraps this in {@link postJson} to swallow failures instead.
+ */
+export async function deliverNotification(
+  message: NotificationMessage,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const res = await fetchImpl(message.url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(message.body),
+  })
+  if (!res.ok) {
+    throw new Error(`POST ${redactUrl(message.url)} failed (${res.status})`)
   }
-  const posts: Promise<void>[] = []
-  if (notifications.slack) {
-    posts.push(postJson(fetchImpl, notifications.slack.webhookUrl, toSlackMessage(payload)))
-  }
-  for (const hook of notifications.webhooks ?? []) {
-    posts.push(postJson(fetchImpl, hook.url, payload))
-  }
-  await Promise.allSettled(posts)
 }
 
 /** Scheme + host only — webhook URLs embed secrets (Slack path, `?token=`). */
@@ -39,18 +139,14 @@ function redactUrl(url: string): string {
   }
 }
 
-async function postJson(fetchImpl: typeof fetch, url: string, body: unknown): Promise<void> {
+/** Inline variant of {@link deliverNotification}: logs failures, never throws. */
+async function postJson(fetchImpl: typeof fetch, message: NotificationMessage): Promise<void> {
   try {
-    const res = await fetchImpl(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
-    if (!res.ok) {
-      console.error(`notify: POST ${redactUrl(url)} failed (${res.status})`)
-    }
+    await deliverNotification(message, fetchImpl)
   }
   catch (err) {
-    console.error(`notify: POST ${redactUrl(url)} threw`, err)
+    // A non-2xx error already names the target; a thrown fetch (network failure)
+    // does not, so include the redacted URL either way.
+    console.error(`notify: POST ${redactUrl(message.url)} failed`, err)
   }
 }

--- a/apps/worker/src/notify.ts
+++ b/apps/worker/src/notify.ts
@@ -126,7 +126,15 @@ export async function consumeNotificationBatch(
         message.retry()
         return
       }
-      message.ack()
+      try {
+        message.ack()
+      }
+      catch (err) {
+        // Delivery already succeeded; a failed ack must not crash the batch or
+        // trigger a retry (that would re-POST a delivered notification). Log in
+        // the file's `notify:` style and let Queues auto-settle the message.
+        console.error(`notify: ack failed after successful delivery`, err)
+      }
     }),
   )
 }

--- a/apps/worker/wrangler.jsonc
+++ b/apps/worker/wrangler.jsonc
@@ -43,8 +43,10 @@
   // `notifications` block in status.config.yml, so no binding is required for
   // the default (free-plan) inline path.
   //
-  // Reliable delivery (opt-in, Workers Paid plan): set `notifications.delivery:
-  // queue` in status.config.yml and uncomment the block below. On a status
+  // Reliable delivery (opt-in): set `notifications.delivery: queue` in
+  // status.config.yml and uncomment the block below. Cloudflare Queues is on the
+  // Workers Free plan (10k ops/day, 24h dead-letter retention); the Paid plan
+  // raises those limits and extends retention to 14 days. On a status
   // change (from either the `scheduled` cron or an inbound Statuspage webhook),
   // the producer enqueues one message per target onto NOTIFY_QUEUE and the
   // `queue` consumer (src/index.ts) does the HTTP dispatch — gaining automatic

--- a/apps/worker/wrangler.jsonc
+++ b/apps/worker/wrangler.jsonc
@@ -40,11 +40,30 @@
 
   // Notifications (src/notify.ts): dispatched inline via `ctx.waitUntil(fetch)`
   // on a status change — Slack + generic webhook targets come from the
-  // `notifications` block in status.config.yml, so no binding is required here.
-  // Follow-up: to add retries/backpressure, put a Workers Queue between the
-  // `scheduled` producer and a `queue` consumer that does the HTTP dispatch —
-  // add a `queues.producers`/`queues.consumers` binding here and a `queue`
-  // handler in src/index.ts.
+  // `notifications` block in status.config.yml, so no binding is required for
+  // the default (free-plan) inline path.
+  //
+  // Reliable delivery (opt-in, Workers Paid plan): set `notifications.delivery:
+  // queue` in status.config.yml and uncomment the block below. The `scheduled`
+  // producer then enqueues one message per target onto NOTIFY_QUEUE and the
+  // `queue` consumer (src/index.ts) does the HTTP dispatch — gaining automatic
+  // retries + backoff and dead-lettering. Create the queues first:
+  //   wrangler queues create statusbeam-notifications
+  //   wrangler queues create statusbeam-notifications-dlq
+  // then add a comma after the `kv_namespaces` `]` above and uncomment:
+  //
+  // "queues": {
+  //   "producers": [
+  //     { "queue": "statusbeam-notifications", "binding": "NOTIFY_QUEUE" }
+  //   ],
+  //   "consumers": [
+  //     {
+  //       "queue": "statusbeam-notifications",
+  //       "max_retries": 5,
+  //       "dead_letter_queue": "statusbeam-notifications-dlq"
+  //     }
+  //   ]
+  // }
   //
   // Cache purge (src/cache.ts): purge-by-Cache-Tag is a REST API feature (on all
   // Cloudflare plans since Apr 2025), not a Worker binding. Provide these as

--- a/apps/worker/wrangler.jsonc
+++ b/apps/worker/wrangler.jsonc
@@ -44,8 +44,9 @@
   // the default (free-plan) inline path.
   //
   // Reliable delivery (opt-in, Workers Paid plan): set `notifications.delivery:
-  // queue` in status.config.yml and uncomment the block below. The `scheduled`
-  // producer then enqueues one message per target onto NOTIFY_QUEUE and the
+  // queue` in status.config.yml and uncomment the block below. On a status
+  // change (from either the `scheduled` cron or an inbound Statuspage webhook),
+  // the producer enqueues one message per target onto NOTIFY_QUEUE and the
   // `queue` consumer (src/index.ts) does the HTTP dispatch — gaining automatic
   // retries + backoff and dead-lettering. Create the queues first:
   //   wrangler queues create statusbeam-notifications

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -86,8 +86,16 @@ describe('notificationsSchema', () => {
     expect(parsed.webhooks).toHaveLength(1)
   })
 
-  it('accepts an empty object (all fields optional)', () => {
-    expect(notificationsSchema.parse({})).toEqual({})
+  it('accepts an empty object (all targets optional) and defaults delivery to inline', () => {
+    expect(notificationsSchema.parse({})).toEqual({ delivery: 'inline' })
+  })
+
+  it('accepts an explicit queue delivery mode', () => {
+    expect(notificationsSchema.parse({ delivery: 'queue' }).delivery).toBe('queue')
+  })
+
+  it('rejects an unknown delivery mode', () => {
+    expect(() => notificationsSchema.parse({ delivery: 'carrier-pigeon' })).toThrow()
   })
 
   it('rejects an invalid slack webhook URL', () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -66,8 +66,10 @@ export type Site = z.infer<typeof siteSchema>
  *   Best-effort — a failed POST is logged, never retried. Works on the free
  *   Workers plan; adequate for the low volume of status-change alerts.
  * - `queue`: enqueue each target onto a Cloudflare Queue whose consumer does
- *   the POST, gaining automatic retries + backoff and dead-lettering. Requires
- *   the Workers Paid plan and the `queues` bindings in wrangler.jsonc.
+ *   the POST, gaining automatic retries + backoff and dead-lettering. Needs the
+ *   `queues` bindings in wrangler.jsonc. Cloudflare Queues is available on the
+ *   Workers Free plan (10k ops/day, 24h dead-letter retention); the Paid plan
+ *   raises those limits and extends retention to 14 days.
  */
 export const notificationDeliverySchema = z.enum(['inline', 'queue'])
 export type NotificationDelivery = z.infer<typeof notificationDeliverySchema>

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -60,10 +60,25 @@ export const siteSchema = z
 export type Site = z.infer<typeof siteSchema>
 
 /**
+ * How status-change notifications reach their targets.
+ *
+ * - `inline` (default): POST each target directly from the run via `fetch`.
+ *   Best-effort — a failed POST is logged, never retried. Works on the free
+ *   Workers plan; adequate for the low volume of status-change alerts.
+ * - `queue`: enqueue each target onto a Cloudflare Queue whose consumer does
+ *   the POST, gaining automatic retries + backoff and dead-lettering. Requires
+ *   the Workers Paid plan and the `queues` bindings in wrangler.jsonc.
+ */
+export const notificationDeliverySchema = z.enum(['inline', 'queue'])
+export type NotificationDelivery = z.infer<typeof notificationDeliverySchema>
+
+/**
  * Optional outbound notification targets. Every field is optional so existing
- * configs without a `notifications` block keep parsing unchanged.
+ * configs without a `notifications` block keep parsing unchanged; `delivery`
+ * defaults to `inline` so adding it never changes existing behavior.
  */
 export const notificationsSchema = z.object({
+  delivery: notificationDeliverySchema.default('inline'),
   slack: z.object({ webhookUrl: z.string().url() }).optional(),
   webhooks: z.array(z.object({ url: z.string().url() })).optional(),
 })

--- a/packages/create-statusbeam/templates/README.md
+++ b/packages/create-statusbeam/templates/README.md
@@ -30,5 +30,10 @@ Commit the updated `wrangler.*.jsonc` (with your real resource ids) afterwards.
 - **Deploy from CI:** push to `main` (set `CLOUDFLARE_API_TOKEN` +
   `CLOUDFLARE_ACCOUNT_ID` as repo secrets first).
 - **Upgrade StatusBeam:** `bunx statusbeam update`, then `bunx statusbeam deploy`.
+- **Reliable notifications (optional):** alerts POST inline by default (no
+  retries) and work on the free plan. For automatic retries + dead-lettering,
+  set `notifications.delivery: queue` in `status.config.yml` and uncomment the
+  `queues` block in `wrangler.worker.jsonc` — this uses Cloudflare Queues, which
+  requires the **Workers Paid plan**.
 
 The page shows sample data until the first cron writes a real snapshot.

--- a/packages/create-statusbeam/templates/README.md
+++ b/packages/create-statusbeam/templates/README.md
@@ -31,9 +31,10 @@ Commit the updated `wrangler.*.jsonc` (with your real resource ids) afterwards.
   `CLOUDFLARE_ACCOUNT_ID` as repo secrets first).
 - **Upgrade StatusBeam:** `bunx statusbeam update`, then `bunx statusbeam deploy`.
 - **Reliable notifications (optional):** alerts POST inline by default (no
-  retries) and work on the free plan. For automatic retries + dead-lettering,
-  set `notifications.delivery: queue` in `status.config.yml` and uncomment the
+  retries). For automatic retries + dead-lettering, set
+  `notifications.delivery: queue` in `status.config.yml` and uncomment the
   `queues` block in `wrangler.worker.jsonc` — this uses Cloudflare Queues, which
-  requires the **Workers Paid plan**.
+  is available on the **Workers Free plan** (10k operations/day, 24h dead-letter
+  retention); the Paid plan raises those limits and extends retention to 14 days.
 
 The page shows sample data until the first cron writes a real snapshot.

--- a/packages/create-statusbeam/templates/status.config.yml
+++ b/packages/create-statusbeam/templates/status.config.yml
@@ -23,6 +23,13 @@ sites:
 # All optional. Keep the real Slack URL out of version control (it's a secret) —
 # upload a private copy, or use a repo secret, rather than committing it here.
 notifications:
+  # How alerts are delivered on a status change:
+  #   inline (default) — POST each target directly. Best-effort, no retries.
+  #                       Works on the free Workers plan.
+  #   queue           — enqueue to a Cloudflare Queue with automatic retries +
+  #                     dead-lettering. Requires the Workers PAID plan and the
+  #                     `queues` bindings in wrangler.worker.jsonc.
+  delivery: inline
   slack:
     webhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX
   webhooks:

--- a/packages/create-statusbeam/templates/status.config.yml
+++ b/packages/create-statusbeam/templates/status.config.yml
@@ -27,8 +27,9 @@ notifications:
   #   inline (default) — POST each target directly. Best-effort, no retries.
   #                       Works on the free Workers plan.
   #   queue           — enqueue to a Cloudflare Queue with automatic retries +
-  #                     dead-lettering. Requires the Workers PAID plan and the
-  #                     `queues` bindings in wrangler.worker.jsonc.
+  #                     dead-lettering. Needs the `queues` bindings in
+  #                     wrangler.worker.jsonc. Queues is on the free Workers plan
+  #                     (10k ops/day, 24h retention); Paid raises those.
   delivery: inline
   slack:
     webhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX

--- a/packages/create-statusbeam/templates/wrangler.worker.jsonc
+++ b/packages/create-statusbeam/templates/wrangler.worker.jsonc
@@ -36,4 +36,24 @@
   //   wrangler secret put CF_API_TOKEN --config wrangler.worker.jsonc
   //   wrangler secret put CF_ZONE_ID   --config wrangler.worker.jsonc
   // When unset, a status change still shows within the 60s edge TTL.
+
+  // Reliable notification delivery (opt-in, Workers PAID plan). Default delivery
+  // is inline `fetch` (no binding needed). To gain retries + dead-lettering, set
+  // `notifications.delivery: queue` in status.config.yml, create the queues:
+  //   wrangler queues create statusbeam-notifications --config wrangler.worker.jsonc
+  //   wrangler queues create statusbeam-notifications-dlq --config wrangler.worker.jsonc
+  // then add a comma after the `kv_namespaces` `]` above and uncomment:
+  //
+  // "queues": {
+  //   "producers": [
+  //     { "queue": "statusbeam-notifications", "binding": "NOTIFY_QUEUE" }
+  //   ],
+  //   "consumers": [
+  //     {
+  //       "queue": "statusbeam-notifications",
+  //       "max_retries": 5,
+  //       "dead_letter_queue": "statusbeam-notifications-dlq"
+  //     }
+  //   ]
+  // }
 }

--- a/packages/create-statusbeam/templates/wrangler.worker.jsonc
+++ b/packages/create-statusbeam/templates/wrangler.worker.jsonc
@@ -37,9 +37,11 @@
   //   wrangler secret put CF_ZONE_ID   --config wrangler.worker.jsonc
   // When unset, a status change still shows within the 60s edge TTL.
 
-  // Reliable notification delivery (opt-in, Workers PAID plan). Default delivery
-  // is inline `fetch` (no binding needed). To gain retries + dead-lettering, set
-  // `notifications.delivery: queue` in status.config.yml, create the queues:
+  // Reliable notification delivery (opt-in). Default delivery is inline `fetch`
+  // (no binding needed). To gain retries + dead-lettering, set
+  // `notifications.delivery: queue` in status.config.yml, create the queues
+  // (Cloudflare Queues is on the free plan — 10k ops/day, 24h retention; Paid
+  // raises those limits and extends retention to 14 days):
   //   wrangler queues create statusbeam-notifications --config wrangler.worker.jsonc
   //   wrangler queues create statusbeam-notifications-dlq --config wrangler.worker.jsonc
   // then add a comma after the `kv_namespaces` `]` above and uncomment:

--- a/status.config.example.yml
+++ b/status.config.example.yml
@@ -38,6 +38,10 @@ sites:
 # All optional. Keep the real Slack URL in the private config you upload to KV,
 # not in this committed example (the webhook URL is a secret).
 notifications:
+  # inline (default): POST each target directly — best-effort, no retries, free
+  # plan. queue: enqueue to a Cloudflare Queue with automatic retries +
+  # dead-lettering (Workers Paid plan; see the queues bindings in wrangler.jsonc).
+  delivery: inline
   slack:
     webhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX
   webhooks:

--- a/status.config.example.yml
+++ b/status.config.example.yml
@@ -38,9 +38,10 @@ sites:
 # All optional. Keep the real Slack URL in the private config you upload to KV,
 # not in this committed example (the webhook URL is a secret).
 notifications:
-  # inline (default): POST each target directly — best-effort, no retries, free
-  # plan. queue: enqueue to a Cloudflare Queue with automatic retries +
-  # dead-lettering (Workers Paid plan; see the queues bindings in wrangler.jsonc).
+  # inline (default): POST each target directly — best-effort, no retries.
+  # queue: enqueue to a Cloudflare Queue with automatic retries + dead-lettering
+  # (see the queues bindings in wrangler.jsonc). Queues is on the free Workers
+  # plan (10k ops/day, 24h retention); Paid raises those limits.
   delivery: inline
   slack:
     webhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

Add an opt-in `notifications.delivery: queue` mode that routes status-change alerts through a Cloudflare Queue with automatic retries + backoff and dead-lettering, without changing the free-tier default (`inline`).

## Changes

- Add `delivery: inline | queue` (default `inline`) to the notifications config schema.
- Refactor `notify.ts` into a shared `buildNotificationMessages` fan-out plus a throwing `deliverNotification` core; inline dispatch swallows failures while the queue consumer retries them.
- `notify()` selects the transport from `notifications.delivery`: when `queue`, the producer enqueues one message per notification target onto a Cloudflare Queue (`NOTIFY_QUEUE` binding); when the binding is missing but `queue` was requested, it falls back to inline (with a warning) so alerts are never silently dropped.
- Add a `queue()` consumer handler in `apps/worker/src/index.ts` that acks delivered messages and retries failures so Cloudflare Queues re-delivers and eventually dead-letters them.
- Add commented-until-enabled `queues` producer/consumer + DLQ bindings to `wrangler.jsonc` and the `create-statusbeam` worker template.
- Document the Workers Paid plan requirement in the templates and examples.
- Cover both delivery modes with tests.

## Related issue

Closes #42

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added or updated, and the suite passes (`bun run test`) — 194 tests pass, worker + core typecheck clean
- [x] Lint/format pass (`bun run lint`) — eslint clean
- [x] Documentation updated if behavior changed — Paid-plan requirement documented in templates/examples
- [x] No breaking change, or a `BREAKING CHANGE:` note is included — purely additive/opt-in, default behavior unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑in Cloudflare Queues path for notification delivery with retries and dead‑lettering (closes #42). Inline stays default; queue mode enqueues per target, chunks to ≤100, and falls back to inline if the binding is missing or an enqueue chunk fails (only the remainder) to avoid drops and double‑delivery.

- **New Features**
  - Added `notifications.delivery: inline | queue` (default `inline`) and a `notify()` selector; `queue()` consumer handles retries + DLQ with a 10s POST timeout.
  - Both cron and webhook paths can enqueue; templates and `wrangler.jsonc` include commented producer/consumer + DLQ.
  - Docs updated: Cloudflare Queues is available on the Workers Free plan (10k ops/day, 24h DLQ retention); Paid raises limits.

- **Bug Fixes**
  - Wrapped `NOTIFY_QUEUE.sendBatch` with try/catch; on partial enqueue failure, only the un‑enqueued remainder is dispatched inline, with `notify:` logs.
  - Separated `ack()` from delivery; swallow `ack()` failures after success, and propagate `retry()` failures so the batch fails and Queues redelivers (prevents silent drops).
  - Expanded tests: inline/queue paths, enqueue‑failure fallback (partial), consumer retry on network/non‑2xx, `retry()`‑throw redelivery, ack‑failure handling, body integrity through the queue, and 100‑message chunking.

<sup>Written for commit cfc78a8a1801326eb8f0155fecc113a219921d90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

