### PR TITLE
fix(core): address feed review findings from PR #41

### DIFF
--- a/apps/web/src/lib/data.ts
+++ b/apps/web/src/lib/data.ts
@@ -88,9 +88,9 @@ let warnedNoConfigKey = false
  * Read and parse the `config` YAML from KV (the same document the check Worker
  * reads), or `null` when KV is unbound, the key is missing, or the read/parse
  * fails. The single config-fetch seam behind {@link getLocale} and
- * {@link getPageName}, so one request that needs both reads KV once. Never
- * throws — every caller degrades to a sensible default rather than breaking the
- * edge render.
+ * {@link getPageName} — one place to parse, warn, and degrade instead of two
+ * copies drifting apart. Never throws — every caller falls back to a sensible
+ * default rather than breaking the edge render.
  */
 async function getConfig(): Promise<StatusConfig | null> {
   const kv = env.STATUS_KV
@@ -108,9 +108,11 @@ async function getConfig(): Promise<StatusConfig | null> {
     // KV is bound but has no `config` key — the deploy step never uploaded it
     // (or the key name is wrong). Warn (once per isolate) so the
     // misconfiguration is debuggable, instead of silently serving defaults.
+    // Name both fallback effects, since one shared warning now covers both
+    // callers (locale via getLocale, feed title via getPageName).
     if (!warnedNoConfigKey) {
       warnedNoConfigKey = true
-      console.warn('getConfig: no `config` key in KV, callers fall back to defaults')
+      console.warn('getConfig: no `config` key in KV — locale falls back to default, feed title to "statusbeam"')
     }
   }
   catch (err) {

--- a/apps/web/src/lib/data.ts
+++ b/apps/web/src/lib/data.ts
@@ -1,4 +1,4 @@
-import type { CheckStatus, DayStat, Incident, Locale, ResponsePoint, SiteSummary } from '@statusbeam/core'
+import type { CheckStatus, DayStat, Incident, Locale, ResponsePoint, SiteSummary, StatusConfig } from '@statusbeam/core'
 import { DEFAULT_LOCALE, parseConfig, resolveLocale } from '@statusbeam/core'
 import { env } from 'cloudflare:workers'
 
@@ -78,49 +78,60 @@ export async function getSite(slug: string): Promise<SiteSummary | undefined> {
 }
 
 // A missing `config` key is a steady-state deploy misconfiguration, so
-// `getLocale()` (invoked on every bare-`/` request) would log it on every hit.
-// Warn once per Worker isolate instead — enough to surface the problem without
-// flooding the logs. (The catch below logs unconditionally: a thrown KV/parse
-// error is exceptional, not steady-state, so each occurrence is worth a line.)
+// `getConfig()` (read on every bare-`/` request via `getLocale`) would log it on
+// every hit. Warn once per Worker isolate instead — enough to surface the
+// problem without flooding the logs. (The catch below logs unconditionally: a
+// thrown KV/parse error is exceptional, not steady-state, so each is worth a line.)
 let warnedNoConfigKey = false
 
 /**
- * Resolve the status page's UI locale from the `config` YAML in KV (the same
- * document the check Worker reads). Falls back to the default locale so `astro
- * dev` renders without Cloudflare bindings, and never throws — a malformed
- * config degrades to English rather than breaking the render.
+ * Read and parse the `config` YAML from KV (the same document the check Worker
+ * reads), or `null` when KV is unbound, the key is missing, or the read/parse
+ * fails. The single config-fetch seam behind {@link getLocale} and
+ * {@link getPageName}, so one request that needs both reads KV once. Never
+ * throws — every caller degrades to a sensible default rather than breaking the
+ * edge render.
  */
-export async function getLocale(): Promise<Locale> {
+async function getConfig(): Promise<StatusConfig | null> {
   const kv = env.STATUS_KV
-  if (kv) {
-    try {
-      // The KV read is inside the try too: a transient KV error must degrade to
-      // the default locale, not throw — `/`'s middleware fallback depends on
-      // this never failing the redirect.
-      const raw = await kv.get('config')
-      if (raw) {
-        return resolveLocale(parseConfig(raw).theme.locale)
-      }
-      // KV is bound but has no `config` key — the deploy step never uploaded it
-      // (or the key name is wrong). Warn (once per isolate) so the
-      // misconfiguration is debuggable, instead of silently serving the default.
-      if (!warnedNoConfigKey) {
-        warnedNoConfigKey = true
-        console.warn('getLocale: no `config` key in KV, falling back to default locale')
-      }
+  if (!kv) {
+    return null
+  }
+  try {
+    // The KV read is inside the try too: a transient KV error must degrade to a
+    // caller default, not throw — `/`'s middleware locale fallback depends on
+    // this never failing the redirect.
+    const raw = await kv.get('config')
+    if (raw) {
+      return parseConfig(raw)
     }
-    catch (err) {
-      // KV read failure or malformed config: fall back rather than fail the
-      // whole page render, but log it (matching cache.ts/notify.ts) so the
-      // operator can debug why `/` isn't honoring their configured `theme.locale`.
-      console.warn('getLocale: KV read failed or malformed config, falling back to default locale', err)
+    // KV is bound but has no `config` key — the deploy step never uploaded it
+    // (or the key name is wrong). Warn (once per isolate) so the
+    // misconfiguration is debuggable, instead of silently serving defaults.
+    if (!warnedNoConfigKey) {
+      warnedNoConfigKey = true
+      console.warn('getConfig: no `config` key in KV, callers fall back to defaults')
     }
   }
-  return DEFAULT_LOCALE
+  catch (err) {
+    // KV read failure or malformed config: fall back rather than fail the whole
+    // render, but log it (matching cache.ts/notify.ts) so the operator can
+    // debug why their configured `theme.locale`/`name` isn't honored.
+    console.warn('getConfig: KV read failed or malformed config, callers fall back to defaults', err)
+  }
+  return null
 }
 
-// Warn once per isolate on a missing `config` key (see `warnedNoConfigKey`).
-let warnedNoConfigKeyForName = false
+/**
+ * Resolve the status page's UI locale from the `config` YAML in KV. Falls back
+ * to the default locale so `astro dev` renders without Cloudflare bindings, and
+ * never throws — a malformed config degrades to English rather than breaking
+ * the render.
+ */
+export async function getLocale(): Promise<Locale> {
+  const config = await getConfig()
+  return config ? resolveLocale(config.theme.locale) : DEFAULT_LOCALE
+}
 
 /**
  * The status page's display name from the `config` YAML in KV — used as the feed
@@ -128,26 +139,8 @@ let warnedNoConfigKeyForName = false
  * deploy still render a valid feed, and never throws (mirrors {@link getLocale}).
  */
 export async function getPageName(): Promise<string> {
-  const kv = env.STATUS_KV
-  if (kv) {
-    try {
-      const raw = await kv.get('config')
-      if (raw) {
-        return parseConfig(raw).name
-      }
-      // KV bound but no `config` key: warn once per isolate, mirroring
-      // `getLocale` — otherwise a deploy that never uploaded config serves the
-      // default feed title on every hit with nothing pointing at the cause.
-      if (!warnedNoConfigKeyForName) {
-        warnedNoConfigKeyForName = true
-        console.warn('getPageName: no `config` key in KV, falling back to default name')
-      }
-    }
-    catch (err) {
-      console.warn('getPageName: KV read failed or malformed config, falling back to default name', err)
-    }
-  }
-  return 'statusbeam'
+  const config = await getConfig()
+  return config?.name ?? 'statusbeam'
 }
 
 /** ISO timestamp `hours` before now — keeps sample incidents fresh for `astro dev`. */

--- a/packages/core/src/feed.test.ts
+++ b/packages/core/src/feed.test.ts
@@ -155,7 +155,9 @@ describe('feed robustness', () => {
     const broken = incident({ title: undefined as unknown as string })
     expect(() => buildAtomFeed([broken], META)).not.toThrow()
     expect(() => buildRssFeed([broken], META)).not.toThrow()
+    // Both flavors render an empty title element rather than "undefined".
     expect(buildAtomFeed([broken], META)).toContain('<title></title>')
+    expect(buildRssFeed([broken], META)).toContain('<title></title>')
   })
 
   it('does not throw or emit "Invalid Date" when an incident timestamp is unparseable', () => {

--- a/packages/core/src/feed.test.ts
+++ b/packages/core/src/feed.test.ts
@@ -33,6 +33,11 @@ describe('escapeXml', () => {
   it('escapes the five predefined entities', () => {
     expect(escapeXml(`a & b < c > d " e ' f`)).toBe('a &amp; b &lt; c &gt; d &quot; e &apos; f')
   })
+
+  it('returns an empty string for a nullish value (type-asserted KV records)', () => {
+    expect(escapeXml(null)).toBe('')
+    expect(escapeXml(undefined)).toBe('')
+  })
 })
 
 describe('sortIncidentsForFeed', () => {
@@ -77,6 +82,22 @@ describe('incidentContentHtml', () => {
   it('places the most recent update first', () => {
     const html = incidentContentHtml(incident())
     expect(html.indexOf('Identified')).toBeLessThan(html.indexOf('Investigating'))
+  })
+
+  it('escapes a malformed createdAt in the timestamp slot (no raw markup after decode)', () => {
+    // An unparseable createdAt containing markup must be escaped like the body,
+    // not passed through raw into the <small> slot.
+    const html = incidentContentHtml(incident({
+      updates: [update(1, 'investigating', '<script>&', 'body')],
+    }))
+    expect(html).toContain('<small>&lt;script&gt;&amp;</small>')
+    expect(html).not.toContain('<small><script>&</small>')
+  })
+
+  it('does not crash when an update body is missing (nullish from bad KV)', () => {
+    const broken = incident({ updates: [{ id: 1, incidentId: 2, state: 'investigating', body: undefined as unknown as string, createdAt: '2026-01-01T00:00:00.000Z' }] })
+    expect(() => incidentContentHtml(broken)).not.toThrow()
+    expect(incidentContentHtml(broken)).toContain('<strong>Investigating</strong> - </p>')
   })
 })
 
@@ -128,6 +149,13 @@ describe('feed robustness', () => {
       expect(xml).not.toContain('API & DB "outage" <down>')
       expect(xml).toContain('Acme &amp; &lt;Co&gt;')
     }
+  })
+
+  it('does not crash when an incident title is missing (nullish from bad KV)', () => {
+    const broken = incident({ title: undefined as unknown as string })
+    expect(() => buildAtomFeed([broken], META)).not.toThrow()
+    expect(() => buildRssFeed([broken], META)).not.toThrow()
+    expect(buildAtomFeed([broken], META)).toContain('<title></title>')
   })
 
   it('does not throw or emit "Invalid Date" when an incident timestamp is unparseable', () => {

--- a/packages/core/src/feed.ts
+++ b/packages/core/src/feed.ts
@@ -36,8 +36,16 @@ const STATE_LABEL: Record<IncidentState, string> = {
  * HTML content blob embedded in `<content type="html">` / `<description>`. HTML's
  * and XML's special-character sets coincide here, so one function serves both and
  * the double application produces the correct entity-in-entity encoding.
+ *
+ * A nullish value yields the empty string: KV incident records are only
+ * type-asserted, never validated (see `getIncidents`), so a missing `title`/
+ * `body` must degrade to empty rather than crash the whole feed with a
+ * `TypeError` on `undefined.replace`.
  */
-export function escapeXml(value: string): string {
+export function escapeXml(value: string | null | undefined): string {
+  if (value == null) {
+    return ''
+  }
   return value
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -49,13 +57,18 @@ export function escapeXml(value: string): string {
 /**
  * Format an ISO timestamp as `Mon DD, YYYY - HH:MM UTC` (the compact, UTC form
  * Statuspage.io uses inside each update line). Built from UTC getters rather than
- * `Intl` so the output is stable across runtimes and locales. Returns the input
- * unchanged when it isn't a parseable date.
+ * `Intl` so the output is stable across runtimes and locales. Returns the
+ * (escaped) input when it isn't a parseable date.
  */
 function formatUpdateTime(iso: string): string {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) {
-    return iso
+    // This value is embedded in the HTML content blob alongside the (escaped)
+    // body, so escape it too — otherwise a malformed `createdAt` containing
+    // `<`/`>`/`&` would surface as raw markup once a reader entity-decodes the
+    // `type="html"` content. The builder's outer escape only guards XML
+    // well-formedness, not the post-decode HTML.
+    return escapeXml(iso)
   }
   const mon = MONTHS[d.getUTCMonth()]
   const day = String(d.getUTCDate()).padStart(2, '0')


### PR DESCRIPTION
## Summary

Follow-up to #41 (merged). The AI reviewers (Gemini, Greptile, cubic) posted findings just as #41 was squash-merged, so they were never applied. This PR addresses the still-valid ones against `main`.

The three **Gemini [HIGH]** date-parsing findings (`RangeError`/`Invalid Date` from unguarded `toISOString()`/`toUTCString()`) were **already fixed pre-merge** by the review-loop hardening (`toMs`/`resolveBuildMs`), so they are not re-addressed here. **cubic** reported no issues.

## Changes

| Finding | Source | Fix |
| --- | --- | --- |
| `escapeXml` crashes on a nullish `title`/`body` from a type-asserted KV record (`TypeError: undefined.replace`) | Gemini, MEDIUM | `escapeXml(value: string \| null \| undefined)` returns `""` for nullish |
| `formatUpdateTime` returns its raw `iso` fallback **unescaped** into the HTML content — a malformed `createdAt` with `<`/`>`/`&` leaks raw markup after a reader decodes the content | Greptile, P2 | escape the fallback (`return escapeXml(iso)`), matching the body |
| `getLocale` and `getPageName` each read+parse `config` from KV independently | Greptile, P2 | consolidate behind a shared `getConfig()` — one KV read, one place for the warn-once / never-throw fallback |

## Verification

- `bun test`: **200 pass** (196 → 200; new tests for nullish `escapeXml`, the escaped timestamp fallback, and missing title/body not crashing the builders)
- `bun run typecheck`: 0 errors · `bun run lint`: clean
- Live smoke test: `/feed.rss` + `/feed.atom` → 200, well-formed XML (xmllint); `/` still redirects via `getLocale`, `/en/` renders (getConfig refactor intact)

Related: #40 (per-incident permalink pages — separate follow-up)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes feed robustness issues and centralizes config loading with clearer fallbacks. Prevents crashes on missing fields and escapes malformed timestamps.

- **Bug Fixes**
  - `packages/core`: `escapeXml` accepts null/undefined and returns "" to avoid crashes on missing `title`/`body`.
  - `packages/core`: `formatUpdateTime` escapes its raw ISO fallback so malformed `createdAt` cannot inject markup.
  - Added tests for nullish `escapeXml`, escaped timestamp fallback, missing fields, and empty `<title>` in both Atom and RSS.

- **Refactors**
  - `apps/web`: Consolidated KV `config` reads into `getConfig()` as a single source of truth for parse/warn/fallback; updated the warn-once message to name both locale and feed-title fallbacks; polished the docstring.

<sup>Written for commit f61175e55f2bc8ed6fbf4e4d819821953644cac9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

