### PR TITLE
chore(skills): add run skills for cli, web, and worker

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,7 +16,8 @@
     "astro@pleaseai": true,
     "claude-md-management@pleaseai": true,
     "bun@pleaseai": true,
-    "turborepo@pleaseai": true
+    "turborepo@pleaseai": true,
+    "agent-browser@pleaseai": true
   },
   "extraKnownMarketplaces": {
     "pleaseai": {

--- a/apps/web/.claude/skills/run-statusbeam-web/SKILL.md
+++ b/apps/web/.claude/skills/run-statusbeam-web/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: run-statusbeam-web
+description: Run, build, and screenshot the StatusBeam status page (apps/web). Use when asked to start, launch, serve, screenshot, or drive the Astro status page / web app, or to confirm a UI change renders.
+---
+
+`apps/web` is `@statusbeam/web` — the StatusBeam **status page**: Astro 7 SSR
+(React islands, Tailwind) that renders a services dashboard, 90-day uptime
+timelines, and an incident feed, deployed to Cloudflare Workers. It reads its
+snapshot from KV but **falls back to built-in SAMPLE data** (`src/lib/data.ts`)
+when no Cloudflare binding is present — so `astro dev` renders a full, realistic
+page with **no D1/KV, no `wrangler login`, no network**.
+
+Drive it with the committed driver: `.claude/skills/run-statusbeam-web/smoke.sh`.
+It starts `astro dev`, asserts the HTTP behavior with `curl`, and screenshots two
+locales through the org-standard browser backend. All paths below are relative to
+`apps/web/`.
+
+## Prerequisites
+
+Repo toolchain only — no system packages. `bun` + `node` (root `mise.toml` pins
+node 24, bun latest) and installed workspace deps (`bun install` at the repo
+root; already present in a checked-out repo). `curl` for the HTTP assertions.
+
+For screenshots, a browser backend per `Skill("please:browser-backend")`
+(order: **orca** inside an Orca worktree → `chromium-cli` → `agent-browser`).
+This skill was authored on the **orca** backend — Orca's embedded browser, which
+drives an internal `agent-browser`. Without any backend the driver still runs
+every HTTP assertion and just skips the shots.
+
+## Run (agent path) — the smoke driver
+
+From `apps/web/`:
+
+```bash
+.claude/skills/run-statusbeam-web/smoke.sh              # start → assert → screenshot → stop
+KEEP_SERVER=1 .claude/skills/run-statusbeam-web/smoke.sh   # leave the dev server up
+```
+
+Exit 0 = every assertion passed. It covers:
+
+1. **Boot** — launches the `astro dev` daemon and reads its URL from the log
+   (Astro auto-bumps the port when 4321 is taken; here it landed on `:4322`).
+2. **HTTP asserts (curl)** — bare `/` 302-redirects to `/en/` (locale negotiated
+   in `src/middleware.ts`); `/en/` renders the SAMPLE sites (Website/API/CDN) and
+   the sample incident; `/api/status.json` returns the degraded-status JSON.
+3. **Screenshots** — `/en/` and `/ko/` (proving i18n routing + translated UI
+   chrome) via the selected backend, saved to `$OUT` (default `/tmp/sb-web/`).
+
+Expected tail:
+
+```
+▸ Screenshotting locales (backend: orca)…
+  ✓ screenshot /en/ → /tmp/sb-web/status-en.png
+  ✓ screenshot /ko/ → /tmp/sb-web/status-ko.png
+
+▸ Summary: 7 passed, 0 failed. Screenshots in /tmp/sb-web/
+```
+
+### Drive it by hand (orca backend — what was verified here)
+
+```bash
+bun run dev                                   # daemonizes; prints "Dev server running at http://localhost:4322"
+curl -s -o /dev/null -w '%{http_code} %header{location}\n' http://localhost:4322/   # → 302 /en/
+orca tab create --url http://localhost:4322/en/ --json    # first time (else: orca goto --url …)
+orca wait --text "Website" --json
+orca full-screenshot --json > /tmp/en.json    # { result: { data: <base64>, format:"png" } }
+node -e 'const r=JSON.parse(require("fs").readFileSync("/tmp/en.json","utf8")).result;require("fs").writeFileSync("/tmp/status-en.png",Buffer.from(r.data,"base64"))'
+bunx astro dev stop                            # stop the daemon
+```
+
+On a non-Orca machine the driver auto-selects `chromium-cli` or `agent-browser`
+(the `agent-browser` plugin is installed). Its branch uses the command shapes
+verified from `agent-browser skills get core`:
+
+```bash
+agent-browser open   http://localhost:4322/en/
+agent-browser wait --text "Website"
+agent-browser screenshot /tmp/status-en.png --full
+agent-browser close
+```
+
+Do not hand-roll headless system Chrome — on macOS it fights the interactive
+Chrome and leaves unreaped processes. And do **not** invoke `agent-browser`
+directly from inside an Orca session: Orca already owns an internal agent-browser,
+so a second one contends and hangs (use the `orca` CLI there — same backend).
+
+## Run (human path)
+
+```bash
+bun run dev     # → http://localhost:4322 ; open it in a browser, then: bunx astro dev stop
+```
+
+`astro dev` here **daemonizes** (it returns immediately and keeps serving in the
+background) — manage it with `bunx astro dev status` / `stop` / `logs`, not Ctrl-C.
+
+## Build / deploy (not run headless here)
+
+`bun run build` (`astro build`) emits a Cloudflare Worker bundle; `bun run
+preview` / `deploy` need `wrangler`. The `@astrojs/cloudflare` adapter fuses the
+wrangler config at **build** time from `STATUSBEAM_WRANGLER_CONFIG` (see
+`astro.config.ts`), which is why the CLI builds per-user — not relevant to a dev
+run.
+
+## Test
+
+```bash
+bun test    # from the repo root; apps/web currently has no package-local test files
+```
+
+## Gotchas
+
+- **No Cloudflare needed in dev.** Every `getSummary`/`getIncidents`/`getLocale`
+  in `src/lib/data.ts` returns SAMPLE data when `env.STATUS_KV` is unbound, so the
+  page is fully populated (3 services, 2 incidents, 90-day timelines) offline.
+  The sample status is deliberately **degraded** (API at 2310 ms) — that's why
+  the banner reads "Degraded Performance", not a bug.
+- **`astro dev` is a daemon, not a foreground process.** `bun run dev` returns
+  and the server keeps running. The driver reads the URL from `dev.log` and stops
+  the daemon on exit; if you start it by hand, `bunx astro dev stop` to clean up.
+- **Port isn't fixed.** Astro uses 4321 by default but auto-bumps (it was `:4322`
+  here). Read the printed URL — don't hardcode.
+- **Inside Orca, use `orca`, not raw `agent-browser`.** Orca owns an internal
+  agent-browser session; invoking `agent-browser open …` directly from an Orca
+  terminal hangs on that contention. The backend selector keys off
+  `TERM_PROGRAM=Orca` / `ORCA_WORKTREE_ID` to route through the `orca` CLI.
+- **Orca screenshots come back as base64 JSON**, not a file — `orca
+  full-screenshot --json` returns `{ result: { data, format } }`; decode it (the
+  driver pipes it through a one-line `node` Buffer write).
+- **`orca full-screenshot` with no open tab errors `browser_no_tab`.** Open one
+  with `orca tab create --url …` first; thereafter `orca goto --url …` reuses it.
+
+## Troubleshooting
+
+- **`✗ dev server never came up`** — check `/tmp/sb-web/dev.log`; usually a stale
+  daemon on the port. `bunx astro dev stop` and re-run (the driver does this
+  automatically at start).
+- **Screenshots skipped, `backend: none`** — no browser backend on PATH. Inside
+  Orca ensure `orca` resolves; otherwise `npm i -g agent-browser && agent-browser
+  install`.
+- **`browser_no_tab` / `browser_stale_ref` from orca** — the tab was closed or
+  navigated; the driver's `tab create`-then-`goto` fallback handles it, but by
+  hand re-run `orca tab create --url …`.

--- a/apps/web/.claude/skills/run-statusbeam-web/smoke.sh
+++ b/apps/web/.claude/skills/run-statusbeam-web/smoke.sh
@@ -54,7 +54,7 @@ shoot() {
         || orca tab create --url "$URL$seg" --json >/dev/null 2>&1   # first call: no tab yet
       orca wait --text "$needle" --json >/dev/null 2>&1
       orca full-screenshot --json 2>/dev/null \
-        | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const r=(JSON.parse(s).result)||{};if(!r.data)process.exit(1);require("fs").writeFileSync(process.argv[1],Buffer.from(r.data,"base64"))})' "$outfile"
+        | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{const r=(JSON.parse(s).result)||{};if(!r.data)process.exit(1);require("fs").writeFileSync(process.argv[1],Buffer.from(r.data,"base64"))}catch{process.exit(1)}})' "$outfile"
       ;;
     chromium-cli)
       chromium-cli >/dev/null 2>&1 <<EOF
@@ -79,7 +79,7 @@ EOF
 close_orca_tabs() {
   [[ -n "${URL:-}" ]] || return 0
   orca tab list --json 2>/dev/null \
-    | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const r=JSON.parse(s).result||{};for(const t of (r.tabs||[]))if((t.url||"").startsWith(process.argv[1]))console.log(t.browserPageId)})' "$URL" \
+    | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{const r=JSON.parse(s).result||{};for(const t of (r.tabs||[]))if((t.url||"").startsWith(process.argv[1]))console.log(t.browserPageId)}catch{}})' "$URL" \
     | while read -r pid; do orca tab close --page "$pid" >/dev/null 2>&1 || true; done
 }
 

--- a/apps/web/.claude/skills/run-statusbeam-web/smoke.sh
+++ b/apps/web/.claude/skills/run-statusbeam-web/smoke.sh
@@ -73,9 +73,24 @@ EOF
   [[ -s "$outfile" ]]
 }
 
+# Close only the Orca tabs pointing at our own dev server — never a tab the user
+# had open (shoot() may `orca goto` an existing tab). Targets the stable
+# browserPageId, so it's index-shift-safe.
+close_orca_tabs() {
+  [[ -n "${URL:-}" ]] || return 0
+  orca tab list --json 2>/dev/null \
+    | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const r=JSON.parse(s).result||{};for(const t of (r.tabs||[]))if((t.url||"").startsWith(process.argv[1]))console.log(t.browserPageId)})' "$URL" \
+    | while read -r pid; do orca tab close --page "$pid" >/dev/null 2>&1 || true; done
+}
+
 cleanup() {
-  [[ "${BACKEND:-}" == agent-browser ]] && agent-browser close >/dev/null 2>&1 || true
-  [[ "${KEEP_SERVER:-0}" == 1 ]] || bunx astro dev stop >/dev/null 2>&1 || true
+  # KEEP_SERVER leaves everything up — the browser session too, not just the server.
+  [[ "${KEEP_SERVER:-0}" == 1 ]] && return 0
+  case "${BACKEND:-}" in
+    agent-browser) agent-browser close >/dev/null 2>&1 || true ;;
+    orca)          close_orca_tabs ;;
+  esac
+  bunx astro dev stop >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 

--- a/apps/web/.claude/skills/run-statusbeam-web/smoke.sh
+++ b/apps/web/.claude/skills/run-statusbeam-web/smoke.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# smoke.sh — launch the StatusBeam status page (apps/web) in Astro dev and drive
+# it end-to-end: assert the bare-`/` locale redirect, the sample-data render, and
+# the JSON API, then screenshot two locales through the org-standard browser
+# backend.
+#
+# The app falls back to built-in SAMPLE data (src/lib/data.ts) when no Cloudflare
+# KV binding is present, so this runs fully offline — no D1/KV, no `wrangler
+# login`, no network.
+#
+# Browser backend selection follows Skill("please:browser-backend"):
+#   orca (inside an Orca worktree) → chromium-cli → agent-browser.
+# This session was authored on the `orca` backend (Orca's embedded browser drives
+# an internal agent-browser); the other two branches are the documented fallbacks
+# for non-Orca machines. Never mix backends, and never use headless system Chrome
+# here — on macOS it fights the interactive Chrome and leaves unreaped processes.
+#
+# Usage (from apps/web/):
+#   .claude/skills/run-statusbeam-web/smoke.sh          # start → assert → screenshot → stop
+#   KEEP_SERVER=1 .claude/skills/run-statusbeam-web/smoke.sh   # leave dev server running
+#
+# Screenshots land in $OUT (default /tmp/sb-web). Exit 0 = every assertion passed.
+set -uo pipefail
+
+WEB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$WEB_DIR"
+OUT="${OUT:-/tmp/sb-web}"; mkdir -p "$OUT"
+pass=0 fail=0
+
+check() { # <label> <condition-cmd...>
+  local label="$1"; shift
+  if "$@"; then printf '  ✓ %s\n' "$label"; ((pass++));
+  else printf '  ✗ %s\n' "$label"; ((fail++)); fi
+}
+
+# ── Pick the browser backend (Skill: please:browser-backend) ─────────────────
+select_backend() {
+  if { [[ "${TERM_PROGRAM:-}" == "Orca" ]] || [[ -n "${ORCA_WORKTREE_ID:-}" ]]; } \
+     && { command -v orca >/dev/null 2>&1 || command -v orca-ide >/dev/null 2>&1; }; then
+    echo orca
+  elif command -v chromium-cli >/dev/null 2>&1; then echo chromium-cli
+  elif command -v agent-browser >/dev/null 2>&1; then echo agent-browser
+  else echo none; fi
+}
+
+# shoot <locale-seg> <wait-text> <outfile> — navigate and save a full-page PNG
+# through whichever backend was selected. Returns success iff a file landed.
+shoot() {
+  local seg="$1" needle="$2" outfile="$3"; rm -f "$outfile"
+  case "$BACKEND" in
+    orca)
+      # `full-screenshot --json` returns { data: <base64>, format }.
+      orca goto --url "$URL$seg" --json >/dev/null 2>&1 \
+        || orca tab create --url "$URL$seg" --json >/dev/null 2>&1   # first call: no tab yet
+      orca wait --text "$needle" --json >/dev/null 2>&1
+      orca full-screenshot --json 2>/dev/null \
+        | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const r=(JSON.parse(s).result)||{};if(!r.data)process.exit(1);require("fs").writeFileSync(process.argv[1],Buffer.from(r.data,"base64"))})' "$outfile"
+      ;;
+    chromium-cli)
+      chromium-cli >/dev/null 2>&1 <<EOF
+open $URL$seg
+wait text=$needle
+screenshot --full $outfile
+EOF
+      ;;
+    agent-browser)
+      # Verified command shapes from `agent-browser skills get core`.
+      agent-browser open "$URL$seg" >/dev/null 2>&1
+      agent-browser wait --text "$needle" >/dev/null 2>&1 || true
+      agent-browser screenshot "$outfile" --full >/dev/null 2>&1
+      ;;
+  esac
+  [[ -s "$outfile" ]]
+}
+
+cleanup() {
+  [[ "${BACKEND:-}" == agent-browser ]] && agent-browser close >/dev/null 2>&1 || true
+  [[ "${KEEP_SERVER:-0}" == 1 ]] || bunx astro dev stop >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# ── Launch the Astro dev daemon ──────────────────────────────────────────────
+# Port: Astro prints its chosen port to the log (it auto-bumps when 4321 is
+# taken), so we read it from there rather than hardcoding. General resolution
+# order when a log isn't available: explicit flag → project docs → package.json
+# dev script → .env PORT → 3000. (See Skill: please:browser-backend.)
+echo "▸ Starting astro dev…"
+bunx astro dev stop >/dev/null 2>&1 || true   # clear any stale daemon
+bun run dev >|"$OUT/dev.log" 2>&1 || true      # `astro dev` daemonizes and returns
+URL=""
+for _ in $(seq 1 60); do
+  URL="$(grep -oE 'http://localhost:[0-9]+' "$OUT/dev.log" | head -1)"
+  [[ -n "$URL" ]] && curl -sf -o /dev/null "$URL/en/" && break
+  sleep 0.5
+done
+[[ -n "$URL" ]] || { echo "✗ dev server never came up"; cat "$OUT/dev.log"; exit 1; }
+echo "  server: $URL"
+
+# ── Assert behavior via curl (no browser needed) ─────────────────────────────
+echo "▸ Asserting HTTP behavior…"
+# Bare `/` negotiates locale in middleware.ts and 302s to a prefixed locale.
+code=$(curl -s -o /dev/null -w '%{http_code}' "$URL/"); loc=$(curl -s -o /dev/null -w '%header{location}' "$URL/")
+check "bare / redirects (302 → /en/)"   test "$code" = 302
+check "  … Location is /en/"            test "$loc" = /en/
+# The rendered page carries the SAMPLE fallback data.
+body="$(curl -s "$URL/en/")"
+check "/en/ renders sample sites (Website + CDN)" bash -c 'grep -q Website <<<"$1" && grep -q CDN <<<"$1"' _ "$body"
+check "/en/ shows the sample incident"  grep -q "Elevated API error rates" <<<"$body"
+# The public JSON status API.
+api="$(curl -s "$URL/api/status.json")"
+check "/api/status.json is degraded-status JSON" grep -q '"status":"degraded"' <<<"$api"
+
+# ── Screenshot two locales through the selected backend ──────────────────────
+BACKEND="$(select_backend)"
+echo "▸ Screenshotting locales (backend: $BACKEND)…"
+if [[ "$BACKEND" == none ]]; then
+  echo "  ! no browser backend — install one: npm i -g agent-browser && agent-browser install"
+  echo "    (HTTP assertions above still cover the render)"
+else
+  check "screenshot /en/ → $OUT/status-en.png" shoot "/en/" "Website"  "$OUT/status-en.png"
+  check "screenshot /ko/ → $OUT/status-ko.png" shoot "/ko/" "성능 저하" "$OUT/status-ko.png"
+fi
+
+echo
+echo "▸ Summary: $pass passed, $fail failed. Screenshots in $OUT/"
+[[ "$fail" == 0 ]]

--- a/apps/worker/.claude/skills/run-statusbeam-worker/SKILL.md
+++ b/apps/worker/.claude/skills/run-statusbeam-worker/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: run-statusbeam-worker
+description: Run, build, and drive the StatusBeam check Worker (apps/worker). Use when asked to start, launch, serve, smoke-test, or curl the Cloudflare Worker — the cron probe and the Statuspage webhook endpoint — or to confirm a webhook/ingest change works.
+---
+
+`apps/worker` is `@statusbeam/worker` — the StatusBeam **check Worker**: a
+Cloudflare Worker with two entrypoints (`src/index.ts`):
+
+- **`fetch`** — inbound Atlassian Statuspage subscriber webhooks at
+  `POST /webhooks/statuspage/:slug` (`src/webhook.ts`), authenticated by a
+  `?token=` shared secret, that ingest a single site's status in real time.
+- **`scheduled`** (cron) — probes every configured site and ingests the batch.
+
+Both feed the same pipeline (`src/ingest.ts`): write a row to D1 `checks`,
+rewrite the KV `summary` the status page reads, and (on a status change) notify +
+purge cache. It's a server, so it's driven with **`wrangler dev` (local
+miniflare) + `curl`** — no real Cloudflare account, no `wrangler login`. Drive it
+with the committed driver: `.claude/skills/run-statusbeam-worker/smoke.sh`.
+
+All paths below are relative to `apps/worker/`.
+
+## Prerequisites
+
+Repo toolchain only — `bun` + `node` (root `mise.toml`) and installed workspace
+deps. `wrangler` ships with this package (`bunx wrangler`, v4). `curl` for the
+HTTP assertions. No system packages.
+
+The Worker imports `@statusbeam/core` from its **built** `dist/` — that build is
+the one non-obvious prerequisite (see Build).
+
+## Build
+
+```bash
+bun run --filter '@statusbeam/core' build   # from the repo root — REQUIRED first
+```
+
+Without it `wrangler dev` fails with `The module "./dist/index.js" was not found`
+— the Worker resolves `@statusbeam/core` to its compiled output, not its source.
+The Worker itself isn't pre-bundled; `wrangler dev` bundles `src/index.ts` on the
+fly.
+
+## Run (agent path) — the smoke driver
+
+From `apps/worker/`:
+
+```bash
+.claude/skills/run-statusbeam-worker/smoke.sh              # build → seed → serve → drive → stop
+PORT=8901 .claude/skills/run-statusbeam-worker/smoke.sh    # override the dev port
+KEEP_SERVER=1 .claude/skills/run-statusbeam-worker/smoke.sh  # leave wrangler dev running
+```
+
+Exit 0 = every assertion passed. It builds core, seeds local D1 + KV, launches
+`wrangler dev` in local mode, then drives:
+
+1. **The webhook status-code matrix** (`fetch`): `404` non-webhook path, `405`
+   GET, `401` no/wrong token (secret fails closed), `404` unknown / non-statuspage
+   slug, `400` malformed / wrong-shaped JSON, `204` event for another component,
+   `200` matching event.
+2. **Ingest side effects** of the `200`: the KV `summary` shows `claude-api →
+   down` and D1 has the mapped check row.
+3. **The cron handler** via `/cdn-cgi/handler/scheduled` → `200` (runs real HTTP
+   checks of the seeded sites).
+4. **Direct invocation** of the pure helpers (`parseWebhookPath`,
+   `timingSafeEqual`).
+5. **The unit test suite** (`bun test`, 19 tests).
+
+Expected tail:
+
+```
+▸ Summary: 15 passed, 0 failed.
+```
+
+### Drive it by hand
+
+Set up local state and launch (the driver's port default is 8799; wrangler's own
+default is 8787):
+
+```bash
+bun run --filter '@statusbeam/core' build            # from repo root
+bunx wrangler d1 execute statusbeam --local --file=./schema.sql
+bunx wrangler kv key put config --binding=STATUS_KV --local --path=/tmp/sb-worker/config.yml
+bunx wrangler dev --port 8799 --var WEBHOOK_SECRET:s3cret &   # wait for "Ready on http://localhost:8799"
+```
+
+`/tmp/sb-worker/config.yml` must list a `check: statuspage` site — the driver
+seeds one (slug `claude-api`, component `Claude API (api.anthropic.com)`), mirroring
+`src/webhook.handler.test.ts`. Then curl (quote the URL — zsh globs `?`):
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8799/nope"                       # 404
+curl -s -o /dev/null -w '%{http_code}\n' -X POST "http://localhost:8799/webhooks/statuspage/claude-api"  # 401 (no token)
+# 200 ingest: a component_update mapping the configured component to major_outage
+curl -s -o /dev/null -w '%{http_code}\n' -X POST \
+  "http://localhost:8799/webhooks/statuspage/claude-api?token=s3cret" \
+  -H 'content-type: application/json' --data-binary @/tmp/sb-worker/major.json
+bunx wrangler kv key get summary --binding=STATUS_KV --local     # → claude-api "status":"down"
+bunx wrangler d1 execute statusbeam --local --command "SELECT slug,status FROM checks ORDER BY id DESC LIMIT 2"
+curl -s "http://localhost:8799/cdn-cgi/handler/scheduled"        # trigger cron
+```
+
+### Direct invocation
+
+The pure routing/auth helpers many PRs touch, without a running Worker:
+
+```bash
+NODE_ENV=test bun -e 'import("./src/webhook.ts").then(m => console.log(m.parseWebhookPath("/webhooks/statuspage/claude-api"), m.timingSafeEqual("a","a")))'
+# → { slug: "claude-api" } true
+```
+
+## Run (human path)
+
+```bash
+bunx wrangler dev    # serves on http://localhost:8787 ; Ctrl-C to stop
+```
+
+Useful for interactive curling, but on its own it has **no config in KV and no D1
+schema**, so any webhook past the auth gate 500s/404s and `scheduled` throws
+`No config in KV`. Seed local state first (see above).
+
+## Test
+
+```bash
+bun test    # 19 pass, 0 fail — from apps/worker/
+```
+
+## Gotchas
+
+- **Build `@statusbeam/core` first** or `wrangler dev` won't start (`./dist/index.js`
+  not found). The Worker imports the package's compiled output, not its `src`.
+- **Cron isn't auto-triggered in local dev.** `wrangler dev` prints "Scheduled
+  Workers are not automatically triggered during local development" — hit
+  `curl http://localhost:<port>/cdn-cgi/handler/scheduled` to fire it manually.
+- **`WEBHOOK_SECRET` fails closed.** With it unset, *every* webhook POST → 401,
+  even a correct-looking one. Pass it with `wrangler dev --var WEBHOOK_SECRET:…`
+  (or a `.dev.vars` file, gitignored) to exercise anything past auth.
+- **The 200 path needs three things aligned:** the secret set, the KV `config`
+  seeded with a `check: statuspage` site, and the payload's `component.name`
+  matching that site's `component:`. Otherwise you get 401 / 404 / 204 instead —
+  each is a *correct* response, not a failure.
+- **zsh globs `?token=`.** Quote every webhook URL or the shell errors with "no
+  matches found" before curl even runs.
+- **Local state persists in `.wrangler/` (gitignored).** D1 rows accumulate
+  across driver runs; the schema (`CREATE … IF NOT EXISTS`) and KV seed are
+  idempotent, so re-runs stay green.
+- **Not a browser/GUI surface** — there's nothing to screenshot; the status
+  codes + KV/D1 side effects are the observable behavior.
+
+## Troubleshooting
+
+- **`The module "./dist/index.js" was not found`** — run the core build (Build
+  section).
+- **`✗ wrangler dev never became ready`** — check `/tmp/sb-worker/dev.log`;
+  usually a port already in use (pass a different `PORT=…`) or a core build that
+  didn't run.
+- **Webhook 401 when you expect 200** — `WEBHOOK_SECRET` unset or token mismatch.
+- **Webhook 404 "Unknown site" / cron `No config in KV`** — the KV `config` key
+  isn't seeded into the same local state; re-run the `wrangler kv key put … --local`
+  step from `apps/worker/`.

--- a/apps/worker/.claude/skills/run-statusbeam-worker/smoke.sh
+++ b/apps/worker/.claude/skills/run-statusbeam-worker/smoke.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# smoke.sh — build, launch, and drive the StatusBeam check Worker (apps/worker).
+#
+# The Worker has two entrypoints (src/index.ts): a `fetch` handler for inbound
+# Atlassian Statuspage webhooks (POST /webhooks/statuspage/:slug) and a
+# `scheduled` (cron) handler that probes the configured sites. This driver runs
+# it under `wrangler dev` in LOCAL mode (miniflare — local D1 + KV, no real
+# Cloudflare account) and drives it with curl:
+#   1. build @statusbeam/core (the Worker imports its built dist)
+#   2. apply the D1 schema + seed the KV `config` key into local state
+#   3. launch `wrangler dev` with a WEBHOOK_SECRET
+#   4. curl the full webhook status-code matrix (404/405/401/404/400/204/200)
+#   5. assert the 200 path's ingest side effects (KV summary + D1 row)
+#   6. trigger the cron handler and confirm it writes check rows
+#   7. direct-invoke the pure routing/auth helpers
+#   8. run the unit test suite
+#
+# Usage (from apps/worker/):
+#   .claude/skills/run-statusbeam-worker/smoke.sh
+#   PORT=8901 .claude/skills/run-statusbeam-worker/smoke.sh   # override the dev port
+#   KEEP_SERVER=1 .claude/skills/run-statusbeam-worker/smoke.sh
+#
+# Exit 0 = every assertion passed. Local state lives in .wrangler/ (gitignored).
+set -uo pipefail
+
+WORKER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+REPO_ROOT="$(cd "$WORKER_DIR/../.." && pwd)"
+cd "$WORKER_DIR"
+OUT="${OUT:-/tmp/sb-worker}"; mkdir -p "$OUT"
+# Port resolution order (Skill: please:browser-backend / dev-server rule):
+# explicit $PORT → package.json dev script (`wrangler dev`, no port) → wrangler
+# default 8787. We pass an explicit port to avoid colliding with a real 8787.
+PORT="${PORT:-8799}"
+SECRET="s3cret"
+B="http://localhost:$PORT"
+pass=0 fail=0
+
+eq() { # <label> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then printf '  ✓ %s (%s)\n' "$1" "$3"; ((pass++));
+  else printf '  ✗ %s: expected %s, got %s\n' "$1" "$2" "$3"; ((fail++)); fi
+}
+code() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
+
+cleanup() {
+  [[ "${KEEP_SERVER:-0}" == 1 ]] || pkill -f "wrangler dev --port $PORT" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# ── 1. Build the core dependency (Worker imports @statusbeam/core/dist) ───────
+echo "▸ Building @statusbeam/core…"
+( cd "$REPO_ROOT" && bun run --filter '@statusbeam/core' build ) >/dev/null 2>&1 \
+  || { echo "✗ core build failed"; exit 1; }
+
+# ── 2. Seed local D1 + KV ────────────────────────────────────────────────────
+echo "▸ Seeding local D1 schema + KV config…"
+cat > "$OUT/config.yml" <<'YML'
+name: Test
+sites:
+  - name: Claude API
+    url: https://status.claude.com
+    check: statuspage
+    component: Claude API (api.anthropic.com)
+  - name: Website
+    url: https://example.com
+    check: http
+theme:
+  darkMode: true
+YML
+bunx wrangler d1 execute statusbeam --local --file=./schema.sql >/dev/null 2>&1 \
+  || { echo "✗ D1 schema apply failed"; exit 1; }
+bunx wrangler kv key put config --binding=STATUS_KV --local --path="$OUT/config.yml" >/dev/null 2>&1 \
+  || { echo "✗ KV seed failed"; exit 1; }
+
+# ── 3. Launch wrangler dev (local) ───────────────────────────────────────────
+echo "▸ Starting wrangler dev on port ${PORT}…"
+pkill -f "wrangler dev --port $PORT" >/dev/null 2>&1 || true; sleep 1
+rm -f "$OUT/dev.log"
+nohup bunx wrangler dev --port "$PORT" --var "WEBHOOK_SECRET:$SECRET" >|"$OUT/dev.log" 2>&1 &
+for _ in $(seq 1 80); do
+  grep -qE "Ready on http" "$OUT/dev.log" && break
+  sleep 0.5
+done
+grep -qE "Ready on http" "$OUT/dev.log" || { echo "✗ wrangler dev never became ready"; tail -20 "$OUT/dev.log"; exit 1; }
+echo "  ready: $(grep -oE 'Ready on http://localhost:[0-9]+' "$OUT/dev.log" | head -1)"
+
+# ── 4. Webhook status-code matrix ────────────────────────────────────────────
+# Payloads mirror src/webhook.handler.test.ts.
+printf '%s' '{"page":{"id":"p1","status_indicator":"major"},"component_update":{"component_id":"abc","new_status":"major_outage"},"component":{"id":"abc","name":"Claude API (api.anthropic.com)","status":"major_outage"}}' > "$OUT/major.json"
+printf '%s' '{"component":{"id":"def","name":"claude.ai","status":"operational"}}' > "$OUT/other.json"
+printf '%s' '{"page":"oops"}' > "$OUT/wrongshape.json"
+printf '%s' 'not-json'        > "$OUT/notjson.json"
+J='content-type: application/json'
+echo "▸ Driving the webhook route…"
+eq "404 non-webhook path"          404 "$(code "$B/nope")"
+eq "405 GET on webhook route"      405 "$(code "$B/webhooks/statuspage/claude-api?token=$SECRET")"
+eq "401 POST without token"        401 "$(code -X POST "$B/webhooks/statuspage/claude-api")"
+eq "401 wrong token"               401 "$(code -X POST "$B/webhooks/statuspage/claude-api?token=WRONG" -H "$J" --data-binary @"$OUT/major.json")"
+eq "404 unknown slug"              404 "$(code -X POST "$B/webhooks/statuspage/nope?token=$SECRET" -H "$J" --data-binary @"$OUT/major.json")"
+eq "404 non-statuspage slug"       404 "$(code -X POST "$B/webhooks/statuspage/website?token=$SECRET" -H "$J" --data-binary @"$OUT/major.json")"
+eq "400 malformed JSON"            400 "$(code -X POST "$B/webhooks/statuspage/claude-api?token=$SECRET" -H "$J" --data-binary @"$OUT/notjson.json")"
+eq "400 wrong-shaped payload"      400 "$(code -X POST "$B/webhooks/statuspage/claude-api?token=$SECRET" -H "$J" --data-binary @"$OUT/wrongshape.json")"
+eq "204 event for other component" 204 "$(code -X POST "$B/webhooks/statuspage/claude-api?token=$SECRET" -H "$J" --data-binary @"$OUT/other.json")"
+eq "200 matching event (ingest)"   200 "$(code -X POST "$B/webhooks/statuspage/claude-api?token=$SECRET" -H "$J" --data-binary @"$OUT/major.json")"
+
+# ── 5. Ingest side effects ───────────────────────────────────────────────────
+echo "▸ Verifying ingest side effects…"
+summary="$(bunx wrangler kv key get summary --binding=STATUS_KV --local 2>/dev/null)"
+if grep -q '"slug":"claude-api"' <<<"$summary" && grep -q '"status":"down"' <<<"$summary"; then
+  printf '  ✓ KV summary shows claude-api → down\n'; ((pass++))
+else printf '  ✗ KV summary missing claude-api/down\n'; ((fail++)); fi
+rows="$(bunx wrangler d1 execute statusbeam --local --command "SELECT COUNT(*) AS n FROM checks WHERE slug='claude-api' AND status='down'" 2>/dev/null)"
+if grep -qE '"n": [1-9]' <<<"$rows"; then printf '  ✓ D1 has a claude-api/down check row\n'; ((pass++));
+else printf '  ✗ D1 has no claude-api/down row\n'; ((fail++)); fi
+
+# ── 6. Cron trigger ──────────────────────────────────────────────────────────
+# wrangler dev exposes the scheduled handler at /cdn-cgi/handler/scheduled. It
+# runs real HTTP checks of the seeded sites (needs network).
+echo "▸ Triggering the cron handler…"
+eq "cron endpoint 200" 200 "$(code "$B/cdn-cgi/handler/scheduled")"
+
+# ── 7. Direct-invoke pure helpers ────────────────────────────────────────────
+echo "▸ Direct-invoking pure helpers…"
+if NODE_ENV=test bun -e '
+import { parseWebhookPath, timingSafeEqual } from "'"$WORKER_DIR"'/src/webhook.ts"
+const ok =
+  JSON.stringify(parseWebhookPath("/webhooks/statuspage/claude-api")) === "{\"slug\":\"claude-api\"}" &&
+  parseWebhookPath("/nope") === null &&
+  timingSafeEqual("abc","abc") === true &&
+  timingSafeEqual("abc","abd") === false
+process.exit(ok ? 0 : 1)
+' >/dev/null 2>&1; then printf '  ✓ parseWebhookPath + timingSafeEqual\n'; ((pass++));
+else printf '  ✗ pure-helper direct invocation\n'; ((fail++)); fi
+
+# ── 8. Test suite ────────────────────────────────────────────────────────────
+echo "▸ Running the unit test suite…"
+if bun test >/dev/null 2>&1; then printf '  ✓ bun test passed\n'; ((pass++));
+else printf '  ✗ bun test failed\n'; ((fail++)); fi
+
+echo
+echo "▸ Summary: $pass passed, $fail failed."
+[[ "$fail" == 0 ]]

--- a/apps/worker/.claude/skills/run-statusbeam-worker/smoke.sh
+++ b/apps/worker/.claude/skills/run-statusbeam-worker/smoke.sh
@@ -70,6 +70,11 @@ bunx wrangler d1 execute statusbeam --local --file=./schema.sql >/dev/null 2>&1 
   || { echo "✗ D1 schema apply failed"; exit 1; }
 bunx wrangler kv key put config --binding=STATUS_KV --local --path="$OUT/config.yml" >/dev/null 2>&1 \
   || { echo "✗ KV seed failed"; exit 1; }
+# Reset prior-run side effects (.wrangler local state persists across runs) so the
+# ingest assertions below verify rows/summary written by THIS run's webhook POST,
+# not a stale row/summary that would let the check false-green.
+bunx wrangler d1 execute statusbeam --local --command "DELETE FROM checks" >/dev/null 2>&1 || true
+bunx wrangler kv key delete summary --binding=STATUS_KV --local >/dev/null 2>&1 || true
 
 # ── 3. Launch wrangler dev (local) ───────────────────────────────────────────
 echo "▸ Starting wrangler dev on port ${PORT}…"

--- a/packages/cli/.claude/skills/run-statusbeam-cli/SKILL.md
+++ b/packages/cli/.claude/skills/run-statusbeam-cli/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: run-statusbeam-cli
+description: Build, run, and drive the statusbeam CLI (packages/cli). Use when asked to run, start, build, smoke-test, or exercise the statusbeam command-line tool, check its exit codes, or drive its setup/deploy/update commands.
+---
+
+`packages/cli` is `@statusbeam/cli` — the `statusbeam` command-line tool that
+provisions, configures, and deploys a StatusBeam status page to Cloudflare. It's
+a small dependency-free-arg-parsing Node CLI (`setup` / `deploy` / `update`,
+plus `--help`/`--version`). Drive it with the committed smoke script:
+`.claude/skills/run-statusbeam-cli/smoke.sh` — it builds the binary, runs it
+through every offline arg/error/prerequisite path, direct-invokes the internal
+pure functions, and runs the unit tests. No Cloudflare account or network needed.
+
+All paths below are relative to `packages/cli/`.
+
+## Prerequisites
+
+Only the repo toolchain — no system packages. `bun` and `node` (both pinned in
+the root `mise.toml`: node 24, bun latest). Workspace deps must be installed
+(`bun install` from the repo root; they already are in a checked-out repo — the
+CLI resolves `wrangler`/`astro` from the sibling `@statusbeam/web` package).
+
+```bash
+bun --version   # 1.3.14 here
+node --version  # v24.x
+```
+
+## Build
+
+```bash
+bun run build   # bun build src/cli.ts → dist/cli.js (ESM, node target, +shebang)
+```
+
+Produces an executable `dist/cli.js` (`#!/usr/bin/env node`). Runnable as
+`node dist/cli.js …` or `./dist/cli.js …`.
+
+## Run (agent path) — the smoke driver
+
+This is the primary way to drive the CLI. From `packages/cli/`:
+
+```bash
+.claude/skills/run-statusbeam-cli/smoke.sh            # build + drive + direct-invoke + test
+.claude/skills/run-statusbeam-cli/smoke.sh --no-build # skip build (binary already built)
+```
+
+Exit 0 = every assertion passed; non-zero = first failure (with its output).
+The driver covers three layers:
+
+1. **The built binary** — `--version`, `--help`, no-args→help, and the error
+   paths (`unknown command`, `unknown option`, `--cwd` missing value) with their
+   expected exit codes; plus the `setup`/`deploy` **prerequisite gates** against
+   an unscaffolded dir (they die with a clear "scaffold a project first" message,
+   no crash).
+2. **Direct invocation** of the internal pure functions most PRs touch —
+   `detectPackageManager` / `upgradeArgs` (src/commands/update.ts), `injectIds` /
+   `normalizeDomain` (src/lib/apply-config.ts) — imported straight from TS source.
+3. **The unit test suite** (`bun test`, 28 tests).
+
+Expected tail:
+
+```
+▸ Summary: 10 passed, 0 failed
+```
+
+### Drive individual commands by hand
+
+```bash
+node dist/cli.js --version          # → 0.0.0 (see Gotchas), exit 0
+node dist/cli.js --help             # usage + command list, exit 0
+node dist/cli.js frobnicate         # ✗ unknown command …, exit 1
+node dist/cli.js setup --cwd /tmp/x --yes   # ✗ missing wrangler.worker.jsonc, exit 1
+```
+
+### Direct-invoke a single internal function
+
+The layer most PRs touch — no build, no full dispatch, no network:
+
+```bash
+NODE_ENV=test bun -e "import('./src/commands/update.ts').then(m => console.log(m.upgradeArgs('yarn', true)))"
+# → [ "up", "@statusbeam/cli", "@statusbeam/core", "@statusbeam/worker", "@statusbeam/web" ]
+```
+
+## Run (human path)
+
+`bun run build && ./dist/cli.js setup` in a *scaffolded* StatusBeam project
+(one made by `bunx create-statusbeam`, holding `status.config.yml` +
+`wrangler.worker.jsonc` + `wrangler.web.jsonc`). It is interactive and, past the
+prerequisite/auth gates, makes real Cloudflare API calls — not runnable to
+completion in a headless container without a scaffolded project and
+`wrangler login` / `CLOUDFLARE_API_TOKEN`.
+
+## Test
+
+```bash
+bun test   # 28 pass, 0 fail — from packages/cli/
+```
+
+## Gotchas
+
+- **`--version` prints `0.0.0` in-repo.** The bundle reads `../package.json`
+  relative to itself, and `packages/cli/package.json` is `0.0.0` (unreleased in
+  the monorepo). Not a bug — it reflects the real version only in a published
+  install.
+- **`setup`/`deploy` are gated twice before doing anything.** First a file-
+  existence check (needs `status.config.yml` + both `wrangler.*.jsonc`), then a
+  Cloudflare auth check (`wrangler whoami`). Both surface as `die()` → exit 1
+  with a clear message. That's why the driver can exercise the command layer
+  fully offline: it only reaches the gates, never real Cloudflare calls.
+- **Don't drive `update` end-to-end to "smoke" it.** It shells out to the
+  detected package manager (`bun/pnpm/yarn/npm update @statusbeam/*`), which hits
+  the registry and rewrites the lockfile. Test its logic via direct invocation
+  (`detectPackageManager` / `upgradeArgs` / `isYarnBerry`) instead — the driver
+  does exactly this.
+- **`wrangler`/`astro` are resolved from `@statusbeam/web`, not globally.** The
+  CLI (`src/lib/project.ts`) resolves those bins from the installed web package's
+  own context, so a global wrangler is irrelevant and the workspace must be
+  installed for `deploy` to find them.
+
+## Troubleshooting
+
+- **`dist/cli.js not found`** — run `bun run build` first (or run the driver
+  without `--no-build`).
+- **`Cannot find module '@statusbeam/web/package.json'`** from `setup`/`deploy`
+  past the file gate — workspace deps aren't installed; run `bun install` at the
+  repo root.
+- **Direct-invoke import errors** — imports must use an absolute path to
+  `src/*.ts` (the driver writes the helper with `$CLI_DIR` baked in); a bare
+  relative path resolves against the script's own location, not `packages/cli/`.

--- a/packages/cli/.claude/skills/run-statusbeam-cli/SKILL.md
+++ b/packages/cli/.claude/skills/run-statusbeam-cli/SKILL.md
@@ -43,7 +43,8 @@ This is the primary way to drive the CLI. From `packages/cli/`:
 .claude/skills/run-statusbeam-cli/smoke.sh --no-build # skip build (binary already built)
 ```
 
-Exit 0 = every assertion passed; non-zero = first failure (with its output).
+Exit 0 = every assertion passed; non-zero = one or more assertions failed (all
+failures are printed before exit).
 The driver covers three layers:
 
 1. **The built binary** — `--version`, `--help`, no-args→help, and the error

--- a/packages/cli/.claude/skills/run-statusbeam-cli/smoke.sh
+++ b/packages/cli/.claude/skills/run-statusbeam-cli/smoke.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# smoke.sh — build and drive the statusbeam CLI end-to-end, asserting exit codes
+# and output. This is the agent-facing driver for `packages/cli`: it exercises the
+# real built binary (arg parsing, help/version, error paths, prerequisite gates)
+# and then the internal pure functions via direct invocation (the layer most PRs
+# touch). No Cloudflare account or network needed — every path here is offline.
+#
+# Usage (from packages/cli/):
+#   .claude/skills/run-statusbeam-cli/smoke.sh          # build + drive + direct-invoke
+#   .claude/skills/run-statusbeam-cli/smoke.sh --no-build # skip the build step
+#
+# Exit 0 = every assertion passed. Non-zero = the first failing assertion.
+set -uo pipefail
+
+# Resolve packages/cli/ regardless of where this is invoked from.
+CLI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$CLI_DIR"
+
+BIN="$CLI_DIR/dist/cli.js"
+pass=0 fail=0
+
+# assert_code <expected-exit> <label> -- <command...>
+assert_code() {
+  local want="$1" label="$2"; shift 3   # drop want, label, and the "--"
+  local out; out="$("$@" 2>&1)"; local got=$?
+  if [[ "$got" == "$want" ]]; then
+    printf '  ✓ %s (exit %s)\n' "$label" "$got"; ((pass++))
+  else
+    printf '  ✗ %s: expected exit %s, got %s\n' "$label" "$want" "$got"
+    printf '    output: %s\n' "$out"; ((fail++))
+  fi
+}
+
+# assert_contains <label> <needle> -- <command...>
+assert_contains() {
+  local label="$1" needle="$2"; shift 3
+  local out; out="$("$@" 2>&1)"
+  if [[ "$out" == *"$needle"* ]]; then
+    printf '  ✓ %s (found "%s")\n' "$label" "$needle"; ((pass++))
+  else
+    printf '  ✗ %s: output missing "%s"\n' "$label" "$needle"
+    printf '    output: %s\n' "$out"; ((fail++))
+  fi
+}
+
+# ── Build ──────────────────────────────────────────────────────────────────
+if [[ "${1:-}" != "--no-build" ]]; then
+  echo "▸ Building CLI (bun run build)…"
+  bun run build >/dev/null || { echo "✗ build failed"; exit 1; }
+fi
+[[ -x "$BIN" ]] || { echo "✗ $BIN not found — run without --no-build"; exit 1; }
+
+# ── Drive the real binary ────────────────────────────────────────────────────
+echo "▸ Driving the built binary…"
+assert_code    0 "--version"              -- node "$BIN" --version
+assert_contains  "--help lists commands"  "statusbeam setup" -- node "$BIN" --help
+assert_code    0 "no args prints help"    -- node "$BIN"
+assert_code    1 "unknown command"        -- node "$BIN" frobnicate
+assert_code    1 "unknown option"         -- node "$BIN" --bogus
+assert_code    1 "--cwd missing value"    -- node "$BIN" setup --cwd --yes
+
+# Prerequisite gates: setup/deploy against an unscaffolded dir must die clearly,
+# not crash — this is the command layer running without any Cloudflare auth.
+EMPTY="$(mktemp -d)"
+assert_contains "setup gate (missing wrangler)" "Scaffold a project first" \
+  -- node "$BIN" setup --cwd "$EMPTY" --yes
+assert_contains "deploy gate (missing config)"  "status.config.yml" \
+  -- node "$BIN" deploy --cwd "$EMPTY"
+rm -rf "$EMPTY"
+
+# ── Direct-invoke internal functions ─────────────────────────────────────────
+# The layer most PRs touch: pure helpers in src/commands + src/lib. Imported and
+# called straight from TS source — no build, no full CLI dispatch, no network.
+echo "▸ Direct-invoking internal functions…"
+DI="$CLI_DIR/.smoke-direct-invoke.mjs"
+cat > "$DI" <<EOF
+import { detectPackageManager, upgradeArgs } from '$CLI_DIR/src/commands/update.ts'
+import { injectIds, normalizeDomain } from '$CLI_DIR/src/lib/apply-config.ts'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+const dir = mkdtempSync(join(tmpdir(), 'sb-'))
+writeFileSync(join(dir, 'bun.lock'), '')
+const checks = [
+  ['detectPackageManager(bun.lock)', detectPackageManager(dir), 'bun'],
+  ['upgradeArgs(bun)[0]',            upgradeArgs('bun')[0], 'update'],
+  ['upgradeArgs(yarn,berry)[0]',     upgradeArgs('yarn', true)[0], 'up'],
+  ['upgradeArgs(yarn,classic)[0]',   upgradeArgs('yarn', false)[0], 'upgrade'],
+  ['injectIds splices id',           injectIds('{"binding":"DB","database_id":"REPLACE_WITH_D1_ID"}', 'abc-123').includes('abc-123'), true],
+  ['normalizeDomain(https://x.dev/)', normalizeDomain('https://x.dev/'), 'x.dev'],
+]
+let bad = 0
+for (const [label, got, want] of checks) {
+  const ok = got === want
+  console.log(\`  \${ok ? '✓' : '✗'} \${label} = \${JSON.stringify(got)}\`)
+  if (!ok) bad++
+}
+process.exit(bad === 0 ? 0 : 1)
+EOF
+if NODE_ENV=test bun run "$DI"; then ((pass++)); else ((fail++)); fi
+rm -f "$DI"
+
+# ── Test suite ───────────────────────────────────────────────────────────────
+echo "▸ Running the unit test suite (bun test)…"
+if bun test >/dev/null 2>&1; then
+  echo "  ✓ bun test passed"; ((pass++))
+else
+  echo "  ✗ bun test failed"; ((fail++))
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo
+echo "▸ Summary: $pass passed, $fail failed"
+[[ "$fail" == 0 ]]

--- a/packages/cli/.claude/skills/run-statusbeam-cli/smoke.sh
+++ b/packages/cli/.claude/skills/run-statusbeam-cli/smoke.sh
@@ -9,7 +9,8 @@
 #   .claude/skills/run-statusbeam-cli/smoke.sh          # build + drive + direct-invoke
 #   .claude/skills/run-statusbeam-cli/smoke.sh --no-build # skip the build step
 #
-# Exit 0 = every assertion passed. Non-zero = the first failing assertion.
+# Exit 0 = every assertion passed. Non-zero = one or more assertions failed (all
+# failures are reported before exit).
 set -uo pipefail
 
 # Resolve packages/cli/ regardless of where this is invoked from.
@@ -76,7 +77,7 @@ DI="$CLI_DIR/.smoke-direct-invoke.mjs"
 cat > "$DI" <<EOF
 import { detectPackageManager, upgradeArgs } from '$CLI_DIR/src/commands/update.ts'
 import { injectIds, normalizeDomain } from '$CLI_DIR/src/lib/apply-config.ts'
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 const dir = mkdtempSync(join(tmpdir(), 'sb-'))
@@ -95,6 +96,7 @@ for (const [label, got, want] of checks) {
   console.log(\`  \${ok ? '✓' : '✗'} \${label} = \${JSON.stringify(got)}\`)
   if (!ok) bad++
 }
+rmSync(dir, { recursive: true, force: true })
 process.exit(bad === 0 ? 0 : 1)
 EOF
 if NODE_ENV=test bun run "$DI"; then ((pass++)); else ((fail++)); fi


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

Add three "run" skills, one per deployable unit, so a future agent can build, launch, and drive each app from a clean checkout:

- `packages/cli/.claude/skills/run-statusbeam-cli/` — drives the `statusbeam` CLI: builds it, runs the real binary through its arg/error/prerequisite-gate matrix, direct-invokes internal helpers, and runs tests.
- `apps/web/.claude/skills/run-statusbeam-web/` — launches the Astro status page (`astro dev`), asserts the locale-redirect/sample-render/JSON-API via curl, and screenshots `/en/` + `/ko/` through the org browser backend (Orca -> chromium-cli -> agent-browser).
- `apps/worker/.claude/skills/run-statusbeam-worker/` — runs the check Worker under `wrangler dev` (local miniflare) and drives the Statuspage webhook status-code matrix, ingest side effects, and cron trigger via curl.

Also enables `agent-browser@pleaseai` in `.claude/settings.json`, the fallback browser backend the web run skill depends on.

## Related issue

N/A

## Checklist

- [x] PR title follows Conventional Commits
- [ ] Tests added or updated, and the suite passes (`bun run test`)
- [ ] Lint/format pass (`bun run lint`)
- [ ] Documentation updated if behavior changed
- [x] No breaking change, or a `BREAKING CHANGE:` note is included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds run skills and smoke scripts for the CLI, web, and worker so you can build, launch, and verify each app from a clean checkout. Hardens the web and worker flows for safer cleanup and reliable results, and enables `agent-browser@pleaseai` for web screenshots.

- **New Features**
  - CLI: builds and runs the `statusbeam` binary; checks help/version, arg and error paths; direct-invokes helpers; runs tests.
  - Web: starts Astro (`astro dev`); asserts `/` redirect, `/en/` render, and `/api/status.json`; screenshots `/en/` and `/ko/` via the org browser backend (fallback `agent-browser@pleaseai`).
  - Worker: runs under `wrangler dev` (local miniflare); drives the webhook status-code matrix; verifies KV/D1 side effects; triggers cron; runs tests.

- **Bug Fixes**
  - Web smoke test: close only Orca tabs for the dev server; honor `KEEP_SERVER`; harden Orca JSON handling to avoid flakes.
  - Worker smoke test: reset local D1 checks and KV `summary` after seeding to prevent false positives from stale `.wrangler` state.
  - CLI: clean up temp dirs in direct-invoke; correct exit-code docs.

<sup>Written for commit f6a79ffd82d61bea82e2a5db15705eedf3eb6f1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

