### PR TITLE
docs: document private/internal pages via Cloudflare Access (ADR-0003)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -85,6 +85,55 @@ a fallback (`workers_dev: true`); (2) the deploy token needs **Zone → Workers 
 and **Zone → DNS: Edit** for that zone, otherwise the deploy fails on
 `/zones/.../workers/routes` with `code: 10000`.
 
+## Private / internal pages (Cloudflare Access)
+
+To restrict a status page to employees or a specific audience, gate it at the **edge**
+with [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/)
+(Zero Trust) rather than adding a login to the app. Access sits **ahead of** the Worker and
+the edge cache, so it needs **no code change** and never serves private content from cache
+to an unauthenticated visitor ([ADR-0003](docs/adr/0003-private-pages-via-cloudflare-access.md)).
+
+**Prerequisite:** a [custom domain](#custom-domain) on a Cloudflare zone in your account.
+Access cannot protect a bare `*.workers.dev` URL — so if you serve a private page, also set
+`workers_dev: false` in `wrangler.web.jsonc` to close the unguarded fallback URL.
+
+### Gate the whole page
+
+1. Cloudflare dashboard → **Zero Trust → Access → Applications → Add an application →
+   Self-hosted**.
+2. Set the application domain to your status page hostname (e.g. `status.internal.example.com`).
+3. Add a policy — **Action: Allow**, e.g. *Emails ending in* `@yourco.com`, or an IdP group
+   (Google, Okta, GitHub, Entra, …) / a one-time PIN. Save.
+
+Everything on the hostname — pages, badges, feeds, and JSON — now requires sign-in.
+
+### Keep badges / feeds / JSON public on a private page (optional)
+
+A blanket gate also blocks the cookie-less machine endpoints — badges
+(`/api/badge/…`, embedded in READMEs), feeds (`/feed.rss`, `/feed.atom`, `/history.*`), and
+JSON (`/api/status.json`). If you want those to stay reachable while the page itself is
+gated, choose per consumer:
+
+- **Public machine endpoints:** add a *second, more-specific* Access application on the
+  sub-path (e.g. `status.internal.example.com/api`) with a **Bypass** policy (*Everyone*).
+  A more-specific path application takes precedence over the hostname one.
+- **Trusted CI / monitors:** issue an Access **service token** and send its
+  `CF-Access-Client-Id` / `CF-Access-Client-Secret` headers, instead of opening the path.
+
+### Public page + separate internal page
+
+Access is all-or-nothing per hostname — it can't show some services publicly and others only
+to staff on one page. To run both, **deploy a second copy** rather than adding visibility
+rules to the app:
+
+1. Copy `wrangler.web.jsonc` to `wrangler.internal.jsonc`; give it a different Worker `name`
+   and an internal `routes` hostname (its own D1/KV, or the same bindings with a separate
+   `status.config.yml` if the service lists differ).
+2. Deploy it alongside the public one:
+   `bunx wrangler deploy --config wrangler.internal.jsonc`.
+3. Put an Access application (above) on the internal hostname only; leave the public
+   hostname open.
+
 ## Optional: instant cache invalidation
 
 On a status change the check Worker purges the edge cache by tag, so updates are

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -94,8 +94,11 @@ the edge cache, so it needs **no code change** and never serves private content 
 to an unauthenticated visitor ([ADR-0003](docs/adr/0003-private-pages-via-cloudflare-access.md)).
 
 **Prerequisite:** a [custom domain](#custom-domain) on a Cloudflare zone in your account.
-Access cannot protect a bare `*.workers.dev` URL — so if you serve a private page, also set
-`workers_dev: false` in `wrangler.web.jsonc` to close the unguarded fallback URL.
+Access cannot protect a bare `*.workers.dev` URL, so a private page must close that unguarded
+fallback by setting `workers_dev: false` in `wrangler.web.jsonc`. Note that `statusbeam setup`
+**manages the networking block** (between its generated markers) and writes `workers_dev: true`
+there — so change it to `false` inside that block, and re-apply after any `setup` re-run (e.g.
+to change the domain), which rewrites the block back to `true`.
 
 ### Gate the whole page
 
@@ -114,9 +117,12 @@ A blanket gate also blocks the cookie-less machine endpoints — badges
 JSON (`/api/status.json`). If you want those to stay reachable while the page itself is
 gated, choose per consumer:
 
-- **Public machine endpoints:** add a *second, more-specific* Access application on the
-  sub-path (e.g. `status.internal.example.com/api`) with a **Bypass** policy (*Everyone*).
-  A more-specific path application takes precedence over the hostname one.
+- **Public machine endpoints:** add a *second, more-specific* Access application with a
+  **Bypass** policy (*Everyone*) for each public path — a more-specific path application takes
+  precedence over the hostname one. Badges and JSON both live under `/api`, so one bypass app
+  on `status.internal.example.com/api` covers them; the **feeds do not** — `/feed.rss`,
+  `/feed.atom`, `/history.rss`, and `/history.atom` sit at the root, so add a bypass app for
+  each (or they stay gated).
 - **Trusted CI / monitors:** issue an Access **service token** and send its
   `CF-Access-Client-Id` / `CF-Access-Client-Secret` headers, instead of opening the path.
 

--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
           items: [
             { label: 'Configuration', slug: 'guides/configuration' },
             { label: 'Deploy to Cloudflare', slug: 'guides/deployment' },
+            { label: 'Private & internal pages', slug: 'guides/private-pages' },
           ],
         },
         {

--- a/apps/docs/src/content/docs/guides/private-pages.mdx
+++ b/apps/docs/src/content/docs/guides/private-pages.mdx
@@ -1,0 +1,129 @@
+---
+title: Private & internal pages
+description: Restrict a status page to your team with Cloudflare Access — an edge identity gate that needs no app code.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+Not every status page is public. To restrict one to employees or a specific
+audience, gate it at the **edge** with [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/)
+(part of Cloudflare Zero Trust) instead of adding a login to the app.
+
+## Why at the edge, not in the app
+
+Cloudflare Access is an identity gate you configure in the Zero Trust dashboard —
+an Access **application** bound to a hostname (or path) plus a **policy** that
+decides who may enter. It runs **ahead of** the StatusBeam Worker and the edge
+cache in Cloudflare's request pipeline, which gives it three properties that make
+it the right layer for this:
+
+- **No app code.** StatusBeam ships no login, session, or authorization logic.
+  Identity, MFA, and session lifetime are handled by Access, wired to your own
+  identity provider (Google, Okta, GitHub, Microsoft Entra, or a one-time PIN).
+- **Cache-safe.** Because Access authenticates *before* the request reaches the
+  cache, private content is never served from cache to an unauthenticated
+  visitor — and the near-instant cache-purge-on-status-change still works.
+- **Composable.** "Fully internal" and "public + internal" are the same
+  primitive — an Access application on a hostname — applied once or twice.
+
+<Aside type="note">
+  This is a deliberate design decision. See [ADR-0003: Private/internal pages via
+  Cloudflare Access](https://github.com/pleaseai/statusbeam/blob/main/docs/adr/0003-private-pages-via-cloudflare-access.md)
+  for the full rationale and the alternatives that were rejected (app-level login,
+  per-service visibility flags).
+</Aside>
+
+## Prerequisite: a custom domain
+
+Access can only protect a hostname on a Cloudflare zone in your account — it
+**cannot** protect a bare `*.workers.dev` URL. So a private page needs a
+[custom domain](/guides/deployment/), and you should also close the unguarded
+fallback URL:
+
+```jsonc
+// wrangler.web.jsonc
+{
+  "workers_dev": false, // don't expose the unauthenticated *.workers.dev URL
+  "routes": [{ "pattern": "status.internal.example.com", "custom_domain": true }],
+}
+```
+
+Without `workers_dev: false`, the page stays reachable — ungated — at its
+`*.workers.dev` address even after you add Access to the custom domain.
+
+## Gate the whole page
+
+<Steps>
+
+1. In the Cloudflare dashboard, go to **Zero Trust → Access → Applications →
+   Add an application → Self-hosted**.
+
+2. Set the application domain to your status page hostname
+   (e.g. `status.internal.example.com`).
+
+3. Add a policy with **Action: Allow**, scoped to your audience — *Emails ending
+   in* `@yourco.com`, an identity-provider group, or a one-time PIN. Save.
+
+4. Visit the page in a fresh browser session: you should be redirected to the
+   Access login before the status page renders.
+
+</Steps>
+
+Everything served on that hostname — the pages, badges, feeds, and JSON API — now
+requires sign-in.
+
+## Keep badges, feeds & JSON public (optional)
+
+A whole-hostname gate also blocks the cookie-less machine endpoints, which are
+meant to be fetched without a browser session:
+
+- **Badges** — `/api/badge/[slug]/uptime.json`, `.../response-time.json`
+  (embedded in READMEs and fetched by GitHub's image proxy)
+- **Feeds** — `/feed.rss`, `/feed.atom`, `/history.rss`, `/history.atom`
+- **JSON** — `/api/status.json`, `/api/status/[slug].json`
+
+For a fully internal page, gating these too is usually what you want. But if you
+need some to stay reachable while the page itself is private, choose per consumer:
+
+- **Public machine endpoints** — add a *second, more-specific* Access application
+  on the sub-path (e.g. `status.internal.example.com/api`) with a **Bypass**
+  policy (*Everyone*). A more-specific path application takes precedence over the
+  hostname-wide one, so `/api/*` opens while everything else stays gated.
+- **Trusted CI / monitors** — issue an Access
+  [service token](https://developers.cloudflare.com/cloudflare-one/identity/service-tokens/)
+  and send its `CF-Access-Client-Id` / `CF-Access-Client-Secret` headers on each
+  request, instead of opening the path to everyone.
+
+## Public page + a separate internal page
+
+Access is all-or-nothing per hostname — it cannot show some services publicly and
+others only to staff *within one page*. To run both, **deploy a second copy**
+rather than adding visibility rules to the app:
+
+<Steps>
+
+1. Copy `wrangler.web.jsonc` to `wrangler.internal.jsonc`. Give it a different
+   Worker `name` and an internal `routes` hostname. Point it at its own D1/KV — or
+   reuse the same bindings with a separate `status.config.yml` if only the service
+   list differs.
+
+2. Deploy it alongside the public one:
+
+   ```bash
+   bunx wrangler deploy --config wrangler.internal.jsonc
+   ```
+
+3. Add an Access application (see [above](#gate-the-whole-page)) on the **internal**
+   hostname only. Leave the public hostname open.
+
+</Steps>
+
+You now have `status.example.com` (public) and `status.internal.example.com`
+(gated) running as two independent Workers, with no per-viewer logic anywhere.
+
+<Aside type="tip">
+  Want defense-in-depth? Access forwards a signed `Cf-Access-Jwt-Assertion` JWT to
+  the Worker on every authenticated request. Verifying it inside the Worker is an
+  optional extra layer — but it is not required, since Access already blocks
+  unauthenticated requests at the edge.
+</Aside>

--- a/apps/docs/src/content/docs/guides/private-pages.mdx
+++ b/apps/docs/src/content/docs/guides/private-pages.mdx
@@ -51,6 +51,13 @@ fallback URL:
 Without `workers_dev: false`, the page stays reachable — ungated — at its
 `*.workers.dev` address even after you add Access to the custom domain.
 
+<Aside type="caution">
+  `statusbeam setup` manages the networking block (between its generated markers)
+  and writes `workers_dev: true` there. Set it to `false` **inside that block**, and
+  re-apply after any `setup` re-run (e.g. to change the domain) — a re-run rewrites
+  the block back to `true`, reopening the ungated URL.
+</Aside>
+
 ## Gate the whole page
 
 <Steps>
@@ -86,9 +93,11 @@ For a fully internal page, gating these too is usually what you want. But if you
 need some to stay reachable while the page itself is private, choose per consumer:
 
 - **Public machine endpoints** — add a *second, more-specific* Access application
-  on the sub-path (e.g. `status.internal.example.com/api`) with a **Bypass**
-  policy (*Everyone*). A more-specific path application takes precedence over the
-  hostname-wide one, so `/api/*` opens while everything else stays gated.
+  with a **Bypass** policy (*Everyone*) for each public path; a more-specific path
+  application takes precedence over the hostname-wide one. Badges and JSON both live
+  under `/api`, so one bypass app on `status.internal.example.com/api` opens both —
+  but the **feeds do not**: `/feed.rss`, `/feed.atom`, `/history.rss`, and
+  `/history.atom` sit at the root, so add a bypass app for each or they stay gated.
 - **Trusted CI / monitors** — issue an Access
   [service token](https://developers.cloudflare.com/cloudflare-one/identity/service-tokens/)
   and send its `CF-Access-Client-Id` / `CF-Access-Client-Secret` headers on each

--- a/docs/adr/0003-private-pages-via-cloudflare-access.md
+++ b/docs/adr/0003-private-pages-via-cloudflare-access.md
@@ -1,0 +1,113 @@
+# ADR 0003 — Private/internal pages via Cloudflare Access
+
+- **Status:** Proposed
+- **Date:** 2026-07-09
+- **Deciders:** StatusBeam maintainers
+
+## Context
+
+StatusBeam serves a **public** status page by default: an Astro SSR Worker on a
+hostname/route, fronted by Workers Cache, reading a snapshot from KV/D1
+(`DEPLOYMENT.md`, ADR-0002). A recurring ask is a **private/internal** status page —
+one visible only to employees or a specific audience, not the public internet.
+
+The question is not *whether* to support it but **where the authentication boundary
+lives**. Three properties of the existing design constrain the answer:
+
+1. **Edge-cache-centric SSR.** Rendered pages are cached per URL at the edge; hits skip
+   the Worker and D1 entirely (`apps/web/wrangler.jsonc` → `cache.enabled: true`).
+   Per-viewer authorization *inside* the app fights this model — a page whose content
+   varies by who is looking cannot be a shared cache entry.
+2. **Package-based distribution (ADR-0002).** The app ships as a versioned dependency;
+   the user's repo holds only `status.config.yml` + two `wrangler.*.jsonc`. Any auth
+   code baked into `@statusbeam/web` becomes complexity **every** deployer carries,
+   configured through *our* abstraction, for an identity provider we don't know.
+3. **Machine-facing endpoints exist.** The web app exposes cookie-less public endpoints
+   meant for automated consumers: badges (`/api/badge/[slug]/*`, embedded in READMEs and
+   fetched by GitHub's image proxy), feeds (`feed.rss`/`feed.atom`/`history.*`), and JSON
+   (`/api/status.json`, `/api/status/[slug].json`). A blanket gate breaks all of them.
+
+Cloudflare Access is an edge identity gate configured in Zero Trust (an Access
+**application** on a hostname/path + a **policy**). It runs **ahead of** the Worker and
+of Workers Cache in the request pipeline, so it can protect a whole status page with
+**zero application code**, and unauthenticated requests never reach cached content.
+
+## Decision
+
+**Authentication for private pages lives at the edge (Cloudflare Access), not in the
+StatusBeam app.** `@statusbeam/web` and `@statusbeam/worker` ship **no login, session, or
+authorization code.** We support two deployment topologies, both configured outside the
+app:
+
+1. **Fully-gated internal page.** Put one Access self-hosted application on the status
+   page's hostname (a custom domain on a Cloudflare zone in your account — `workers.dev`
+   subdomains cannot carry Access), with an Allow policy scoped to an email domain or IdP
+   group. The entire page — pages, badges, feeds, and JSON — is gated. App code unchanged.
+
+2. **Public page + separate internal page.** Keep the public deployment as-is and deploy
+   a **second copy** (a second `wrangler.web.jsonc`: different Worker `name` + hostname,
+   its own `status.config.yml`/KV snapshot) on an internal hostname protected by Access.
+   Two Workers, two configs, one of them gated — no per-viewer logic anywhere.
+
+**Machine endpoints are gated with the page by default.** Deployers who want badges/feeds
+public *while the page is private* opt in explicitly: a more-specific Access application
+on the sub-path (e.g. `status.example.com/api`) with a **Bypass** policy, or an Access
+**service token** for trusted CI/monitors. This is a documented per-deployer decision, not
+a default and not app behavior.
+
+The primary deliverable is therefore **documentation** (a `DEPLOYMENT.md` section) plus
+this ADR fixing the boundary. No change to `apps/web`, `apps/worker`, or `packages/core`.
+
+## Consequences
+
+### Positive
+
+- **Zero app-code surface.** No auth to build, test, version, or CVE-patch in StatusBeam;
+  identity, MFA, and session lifetime are Cloudflare's problem, integrated with the
+  deployer's existing IdP (Google, Okta, GitHub, one-time PIN, …).
+- **Cache model intact.** Access gates ahead of Workers Cache, so private content is never
+  served from cache to an unauthenticated visitor, and cache-purge-by-tag still works.
+- **Composable topologies.** "Fully internal" and "public + internal" are the same
+  primitive (an Access app on a hostname) applied once or twice — no new concepts.
+
+### Negative
+
+- **Out-of-band setup.** Access lives in the Zero Trust dashboard/API, not in
+  `wrangler.*.jsonc`; `statusbeam setup` does not provision it today, so the deployer
+  configures it manually (documented, but a separate step).
+- **Machine endpoints need a conscious choice.** Badges/feeds/JSON break under a blanket
+  gate unless the deployer adds Bypass/service-token policies — a footgun if undocumented,
+  which is exactly why this ADR mandates documenting it.
+- **Two-page topology duplicates a deployment.** Public + internal means two Workers and
+  two configs to keep in sync, rather than one page with visibility rules.
+
+### Neutral
+
+- Requires a **custom domain** on a Cloudflare zone in the account; `workers.dev` alone
+  can't host Access. Most private-page users want a branded internal hostname anyway.
+- Defense-in-depth (verifying the `Cf-Access-Jwt-Assertion` JWT inside the Worker) remains
+  *possible* as a future opt-in but is deliberately **not** required here.
+
+## Alternatives Considered
+
+- **App-level auth (login/session in `@statusbeam/web`).** Puts a password or OAuth flow
+  in the app. Rejected: every deployer inherits auth complexity and an attack surface for
+  an IdP we can't anticipate; it duplicates what Access does better; and per-viewer
+  responses defeat the edge cache the whole architecture is built on.
+- **Per-service visibility in a single page** (`public`/`private` flags per service,
+  filtered by viewer). Rejected as the mechanism: it forces per-viewer rendering (cache
+  fragmentation or bypass), splits the KV snapshot, and still needs *some* auth to know the
+  viewer — i.e. Access anyway. The two-page topology delivers the same outcome with no app
+  change. May be revisited if strong demand appears.
+- **Provision Access from the CLI/Terraform** (`statusbeam setup --access`). Attractive for
+  reproducibility, but `wrangler` cannot manage Access resources — it needs Cloudflare API
+  or Terraform calls, and IdP config varies per org, lowering the payoff for OSS. Deferred:
+  document the manual setup now; add CLI provisioning if demand warrants.
+
+## Follow-up (implementation, not part of this decision)
+
+- Add a **"Private / internal pages (Cloudflare Access)"** section to `DEPLOYMENT.md`:
+  self-hosted application on the hostname, Allow policy, the badge/feed Bypass/service-token
+  opt-in, and the two-page topology recipe.
+- Consider a future `statusbeam setup --access` that provisions the Access application via
+  the Cloudflare API (separate ADR/decision if pursued).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -6,3 +6,4 @@
 |-----|-------|------|--------|
 | [0001](0001-tech-stack.md) | Tech stack | 2026-07-07 | Accepted |
 | [0002](0002-package-based-distribution.md) | Package-based distribution | 2026-07-08 | Proposed |
+| [0003](0003-private-pages-via-cloudflare-access.md) | Private/internal pages via Cloudflare Access | 2026-07-09 | Proposed |


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

Supports internal/private status pages (not just fully public ones) by
recording that authentication for private pages lives at the edge —
Cloudflare Access (Zero Trust) — rather than inside the app. This means
**zero app runtime code changes** are required to support private pages;
the decision is recorded in **ADR-0003** (status: **Proposed** — open for
review/discussion, not yet Accepted).

**This PR is docs-only. No runtime/application code is changed.**

## Changes

- `docs/adr/0003-private-pages-via-cloudflare-access.md` (new) — ADR-0003.
  Covers two supported topologies: (1) fully-gated internal page, and
  (2) public page + separate internal page (deployed as a second
  Worker/copy). Also covers keeping machine endpoints (badges, feeds,
  JSON) reachable via a more-specific Access application with a Bypass
  policy, or Access service tokens. Documents rejected alternatives
  (e.g. building auth into the app).
- `docs/adr/index.md` — registers ADR-0003 in the ADR index table
  (status: Proposed).
- `DEPLOYMENT.md` — new "Private / internal pages (Cloudflare Access)"
  section; this is the authoritative deployment recipe (gate the whole
  page via a Cloudflare Access Self-hosted application; keep
  badges/feeds/JSON public via a more-specific Access app with Bypass
  policy or service tokens; run a public + separate internal page by
  deploying a second Worker copy with its own wrangler config and
  hostname).
- `apps/docs/src/content/docs/guides/private-pages.mdx` (new) —
  self-contained public docs-site guide (Astro Starlight) mirroring the
  same content as the DEPLOYMENT.md section, for the public docs site
  audience.
- `apps/docs/astro.config.ts` — registers the new private-pages guide in
  the docs site sidebar navigation (under the existing guides group,
  after "Deploy to Cloudflare").

## Related issue

None — this PR was authored directly from the deployment/docs need for
private status pages.

## Checklist

- [x] PR title follows Conventional Commits
- [ ] Tests added or updated, and the suite passes (`bun run test`) — N/A, docs-only change
- [ ] Lint/format pass (`bun run lint`)
- [x] Documentation updated if behavior changed
- [x] No breaking change, or a `BREAKING CHANGE:` note is included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents how to run private/internal status pages using Cloudflare Access with no app code changes. Adds ADR-0003 and setup guides for full-site gating, optional public machine endpoints, and running a separate internal page.

- **Documentation**
  - Added ADR-0003 recording the decision to keep auth at the edge (Cloudflare Access, ahead of cache) and rejecting app-level auth.
  - Added a new docs guide “Private & internal pages” and deployment steps: require a custom domain and set `workers_dev: false`, gate the whole page, and run a public + separate internal page via a second `wrangler` config/hostname.
  - Documented how to keep badges/feeds/JSON public on a private page via path-specific Access Bypass or service tokens; noted feeds at root need individual bypass apps.
  - Updated docs navigation to include the new guide and registered ADR-0003 in the ADR index.

<sup>Written for commit 087823f03cbe037efda08476cced231c3fce6ce3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

