### PR TITLE
ci(dependabot): use Bun package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns: ['*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
       actions:
         patterns: ['*']
 
-  # npm/bun dependencies across the monorepo.
-  - package-ecosystem: npm
+  # Bun dependencies across the monorepo.
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary

- configure Dependabot to use the `bun` package ecosystem
- update the adjacent comment to describe Bun dependencies
- leave the GitHub Actions update configuration unchanged

This follows up on the dependency update raised in #56: the repository uses `bun.lock`, which Dependabot supports through the `bun` ecosystem rather than `npm`.

## Validation

- parsed `.github/dependabot.yml` with `Bun.YAML.parse`
- verified the configured ecosystems are `github-actions` and `bun`
- ran `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Dependabot to the `bun` ecosystem so updates target `bun.lock`, and add a 7-day cooldown to pace dependency PRs. Updated the Bun comment; `github-actions` updates remain unchanged.

<sup>Written for commit 5487cf6a0955539c9e7cf12ce9ae5fe4f3782220. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

