### PR TITLE
fix(ci): make the release→publish pipeline actually publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing release tag to publish (e.g. core-v1.0.0)"
+        description: Existing release tag to publish (e.g. core-v1.0.0)
         required: true
         type: string
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,20 @@ name: Publish
 # release-please cuts one GitHub Release per changed package (tags like
 # `core-v0.1.0`, `cli-v0.1.0`). Each published release fires this workflow, which
 # publishes just that package to npm with provenance. See ADR-0002.
+#
+# A release-triggered run executes the workflow file AT THE TAG'S COMMIT, so a
+# fix to this file never reaches already-cut tags. The workflow_dispatch input
+# covers that: it publishes an existing release tag using the current (main)
+# workflow file.
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish (e.g. core-v1.0.0)"
+        required: true
+        type: string
 
 # Least privilege. id-token: write is required for npm provenance (OIDC).
 permissions:
@@ -21,7 +32,7 @@ jobs:
       - name: Resolve package from the release tag
         id: pkg
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           # tags: <component>-v<version> → strip the -v<version> suffix.
           component="${TAG%-v*}"
@@ -39,6 +50,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Build the tagged tree in both trigger modes (checkout would default
+          # to the default branch on workflow_dispatch).
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
           persist-credentials: false
 
       - name: Set up bun
@@ -91,5 +105,9 @@ jobs:
           # before it was dropped). Provenance still works: it keys off the
           # id-token: write OIDC + the GitHub Actions env, not setup-node.
           npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
+          # Publish from outside the repo checkout: inside the Bun workspaces
+          # monorepo, `npm publish <tarball>` enters workspace mode and dies
+          # with ENOWORKSPACES.
+          cd "$dest"
           # npm (not bun) publish: only npm emits the provenance attestation.
           npm publish "$tarball" --provenance --access public

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "group-pull-request-title-pattern": "chore: release ${version}",
+  "group-pull-request-title-pattern": "chore: release ${branch}",
   "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "separate-pull-requests": false,
   "release-search-depth": 500,


### PR DESCRIPTION
## Problem

v1.0.0 was 'released' on 2026-07-07 (release PR #17) yet nothing ever reached npm: no tags, no GitHub Releases, zero `publish.yml` runs. Two independent defects:

1. **release-please could never tag.** `group-pull-request-title-pattern: "chore: release ${version}"` — but `${version}` is empty on a grouped release PR (5 components), so #17 merged titled bare `chore: release`, which the release step then failed to parse on every run since: `✖ Bad pull request title` → `⚠ Expected 5 releases, only found 0` (e.g. [run 30373696494](https://github.com/pleaseai/statusbeam/actions/runs/30373696494)). Fixed by using `${branch}` — the [upstream default](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md), which always substitutes and round-trips.

2. **publish.yml died before contacting the registry.** `npm publish <tarball>` ran from the package dir inside the Bun workspaces monorepo → npm enters workspace mode → `ENOWORKSPACES` ([run 30606032692](https://github.com/pleaseai/statusbeam/actions/runs/30606032692)). Fixed by publishing from the pack destination dir outside the checkout.

Also adds `workflow_dispatch` (tag input) to publish.yml: release-triggered runs execute the workflow file **at the tag's commit**, so already-cut tags (like the five v1.0.0 ones) can never pick up workflow fixes — the dispatch path publishes an existing release tag with the current workflow file.

## Recovery already done out-of-band

- Retitled merged #17 to `chore: release 1.0.0` so the old pattern could parse it. release-please then still failed with `Resource not accessible by integration` on create-a-release ([run 30605935721](https://github.com/pleaseai/statusbeam/actions/runs/30605935721)) — the `pleaseai-release-bot` app installation has no **Workflows** permission, which GitHub can require for release/tag creation. **Follow-up for the app owner:** grant the app Workflows: Read & write (or accept manual tagging).
- Created the five v1.0.0 releases manually (`core|worker|web|cli|create-statusbeam-v1.0.0` at 664ec1d, notes from #17's body) and moved #17 to `autorelease: tagged`.

## After merge

Dispatch `publish.yml` once per tag to publish v1.0.0 with the fixed workflow:

```text
for t in core-v1.0.0 worker-v1.0.0 web-v1.0.0 cli-v1.0.0 create-statusbeam-v1.0.0; do
  gh workflow run publish.yml -f tag=$t
done
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release→publish pipeline so grouped releases tag correctly and each package publishes to `npm`. Adds a manual `workflow_dispatch` path to publish existing release tags with the current workflow.

- **Bug Fixes**
  - `release-please`: use `${branch}` in grouped PR titles so tags and releases are created for multi-package releases.
  - `publish.yml`: publish from the pack destination outside the Bun workspaces to avoid `npm` workspace mode (`ENOWORKSPACES`) and ensure provenance; also fix YAML lint (plain scalar for the `workflow_dispatch` input description).

- **Migration**
  - To publish v1.0.0, run `publish.yml` via `workflow_dispatch` with `tag=<component>-v1.0.0` for each of: `core`, `worker`, `web`, `cli`, `create-statusbeam`.

<sup>Written for commit ca82dca17147db31b3d2ce34c1fef1440299f4e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

