### PR TITLE
fix(ci): publish via npm trusted publishing; run npm outside the workspace

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,10 +69,16 @@ jobs:
           bun-version: 1.3.14
           # This workflow is release-triggered and publishes to npm; a poisoned
           # cache could taint the tarball, so disable caching (zizmor cache-poisoning).
-          # node + npm (used for the provenance publish) come from the runner's
-          # preinstalled toolchain — no actions/setup-node, which would re-introduce
-          # a cache-capable action into the publish path.
           no-cache: true
+
+      - name: Set up node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          # Node 24 bundles the npm >= 11.5.1 that trusted publishing needs —
+          # npm comes from the Node dist tarball, not an ad-hoc registry
+          # install. No `cache:` input, so no cache-capable path in the
+          # publish workflow (zizmor cache-poisoning).
+          node-version: 24
 
       - name: Install dependencies
         # --ignore-scripts: a release-triggered publish must not run arbitrary
@@ -97,9 +103,6 @@ jobs:
       - name: Pack + publish with provenance
         working-directory: ${{ steps.pkg.outputs.dir }}
         run: |
-          # Trusted publishing needs npm >= 11.5.1; the runner's preinstalled
-          # node ships an older one. Version-pinned global install, no cache.
-          npm install -g npm@^11.5.1
           dest="$RUNNER_TEMP/pack"
           mkdir -p "$dest"
           # bun pm pack rewrites workspace:* deps to real versions in the tarball.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,13 +101,13 @@ jobs:
           if [ -z "$tarball" ]; then
             echo "::error::no tarball produced by bun pm pack"; exit 1
           fi
+          # Run every npm command from outside the repo checkout: inside the Bun
+          # workspaces monorepo npm enters workspace mode, and both `npm config
+          # set` and `npm publish <tarball>` die with ENOWORKSPACES there.
+          cd "$dest"
           # Configure the npm registry auth (setup-node's registry-url did this
           # before it was dropped). Provenance still works: it keys off the
           # id-token: write OIDC + the GitHub Actions env, not setup-node.
           npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
-          # Publish from outside the repo checkout: inside the Bun workspaces
-          # monorepo, `npm publish <tarball>` enters workspace mode and dies
-          # with ENOWORKSPACES.
-          cd "$dest"
           # npm (not bun) publish: only npm emits the provenance attestation.
           npm publish "$tarball" --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,9 +76,11 @@ jobs:
         with:
           # Node 24 bundles the npm >= 11.5.1 that trusted publishing needs —
           # npm comes from the Node dist tarball, not an ad-hoc registry
-          # install. No `cache:` input, so no cache-capable path in the
-          # publish workflow (zizmor cache-poisoning).
+          # install. setup-node v5+ turns npm caching ON by default; disable
+          # it so no cache-capable path exists in the publish workflow
+          # (zizmor cache-poisoning).
           node-version: 24
+          package-manager-cache: false
 
       - name: Install dependencies
         # --ignore-scripts: a release-triggered publish must not run arbitrary

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,9 @@ on:
         required: true
         type: string
 
-# Least privilege. id-token: write is required for npm provenance (OIDC).
+# Least privilege. id-token: write is what authenticates the publish: npm
+# trusted publishing exchanges the OIDC token for registry credentials — no
+# NPM_TOKEN secret anywhere — and provenance keys off the same token.
 permissions:
   contents: read
   id-token: write
@@ -27,7 +29,11 @@ jobs:
   publish:
     name: Publish to npm (provenance)
     runs-on: ubuntu-latest
-    environment: npm # holds NPM_TOKEN; add protection rules in repo settings
+    # Must match the environment configured on each npm package's trusted
+    # publisher (npmjs.com → package → Settings → Trusted publisher:
+    # GitHub Actions, repo pleaseai/statusbeam, workflow publish.yml,
+    # environment npm). Add protection rules in repo settings to gate publishes.
+    environment: npm
     steps:
       - name: Resolve package from the release tag
         id: pkg
@@ -90,9 +96,10 @@ jobs:
 
       - name: Pack + publish with provenance
         working-directory: ${{ steps.pkg.outputs.dir }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          # Trusted publishing needs npm >= 11.5.1; the runner's preinstalled
+          # node ships an older one. Version-pinned global install, no cache.
+          npm install -g npm@^11.5.1
           dest="$RUNNER_TEMP/pack"
           mkdir -p "$dest"
           # bun pm pack rewrites workspace:* deps to real versions in the tarball.
@@ -101,13 +108,10 @@ jobs:
           if [ -z "$tarball" ]; then
             echo "::error::no tarball produced by bun pm pack"; exit 1
           fi
-          # Run every npm command from outside the repo checkout: inside the Bun
-          # workspaces monorepo npm enters workspace mode, and both `npm config
-          # set` and `npm publish <tarball>` die with ENOWORKSPACES there.
+          # Publish from outside the repo checkout: inside the Bun workspaces
+          # monorepo npm enters workspace mode and `npm publish <tarball>` dies
+          # with ENOWORKSPACES. No token/config-set — auth is the trusted
+          # publisher OIDC exchange, which also emits the provenance attestation
+          # (npm, not bun: only npm implements it).
           cd "$dest"
-          # Configure the npm registry auth (setup-node's registry-url did this
-          # before it was dropped). Provenance still works: it keys off the
-          # id-token: write OIDC + the GitHub Actions env, not setup-node.
-          npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
-          # npm (not bun) publish: only npm emits the provenance attestation.
           npm publish "$tarball" --provenance --access public


### PR DESCRIPTION
Two changes to `publish.yml`:

1. **Workspace fix (follow-up to #60).** The v0.1.0 publish runs (e.g. [30606885111](https://github.com/pleaseai/statusbeam/actions/runs/30606885111)) still died with `ENOWORKSPACES`: #60 moved only `npm publish` out of the monorepo, but `npm config set` also refuses workspace mode and ran first. Every npm command now runs from the pack destination outside the checkout.

2. **npm trusted publishing (OIDC), NPM_TOKEN dropped.** The job's `id-token: write` is exchanged for registry credentials at publish time — no token secret to store, leak, or rotate — and the same exchange emits the provenance attestation. Needs npm ≥ 11.5.1 (version-pinned global install; the runner's preinstalled npm is older).

## One-time setup this depends on (maintainer)

Trusted publishers can only be configured on **existing** packages, so the first publish is manual:

1. Create the `statusbeam` org on npmjs.com (for the four `@statusbeam/*` packages).
2. `npm login`, then publish the five v0.1.0 tarballs once (packed from tag `core-v0.1.0` = `d0ed3f8`).
3. For each package: npmjs.com → package → Settings → **Trusted publisher** → GitHub Actions → repository `pleaseai/statusbeam`, workflow `publish.yml`, environment `npm`.

After that, every future release publishes tokenlessly. The five `*-v0.1.0` tags carry the broken pre-#60 workflow (release runs execute the workflow at the tag's commit), so any CI re-publish of those goes through the `workflow_dispatch` path — but with the manual first publish, that's not needed.